### PR TITLE
Fix a bug in the get loop

### DIFF
--- a/lib/pay_day_loan.ex
+++ b/lib/pay_day_loan.ex
@@ -539,7 +539,6 @@ defmodule PayDayLoan do
         get(pdl, key, peek_load_state(pdl, key), try_num - 1)
       {:ok, value} -> {:ok, value}
     end
-    pdl.backend.get(pdl, key)
   end
   # if the key is loading, just dwell and try again
   defp get(pdl, key, :loading, try_num) do

--- a/test/pay_day_loan/backends/behaviour_test.exs
+++ b/test/pay_day_loan/backends/behaviour_test.exs
@@ -256,7 +256,7 @@ defmodule PayDayLoan.Backends.BehaviourTest do
     # delete on the backend
     Backend.delete(Cache.pdl(), key)
 
-    assert {:error, :not_found} == Cache.get(key)
+    assert {:error, :failed} == Cache.get(key)
     assert nil == PDL.LoadState.peek(Cache.pdl().load_state_manager, key)
     # we hold onto the knowledge that the key exists
     assert PDL.KeyCache.in_cache?(Cache.pdl().key_cache, key)

--- a/test/pay_day_loan/backends/generic_test.exs
+++ b/test/pay_day_loan/backends/generic_test.exs
@@ -247,7 +247,7 @@ defmodule PayDayLoan.Backends.GenericTest do
     # the deleted key no longer shows up in reduce results
     assert [v2] == Cache.values()
 
-    assert {:error, :not_found} == Cache.get(key)
+    assert {:error, :failed} == Cache.get(key)
     assert nil == PDL.LoadState.peek(Cache.pdl().load_state_manager, key)
     # we hold onto the knowledge that the key exists
     assert PDL.KeyCache.in_cache?(Cache.pdl().key_cache, key)


### PR DESCRIPTION
This appears to have only affected the error returned when a key is
removed from the backend.