### PR TITLE
Make reloads non-blocking

### DIFF
--- a/lib/pay_day_loan.ex
+++ b/lib/pay_day_loan.ex
@@ -350,7 +350,7 @@ defmodule PayDayLoan do
   """
   @spec request_load(pdl :: t, key | [key]) :: :ok
   def request_load(pdl = %PayDayLoan{}, key_or_keys) do
-    LoadState.request(pdl.load_state_manager, key_or_keys)
+    LoadState.request_or_reload(pdl.load_state_manager, key_or_keys)
     GenServer.cast(pdl.load_worker, :ping)
     :ok
   end
@@ -521,7 +521,7 @@ defmodule PayDayLoan do
   end
   # if we're already loaded, we just have to grab the pid
   #    this is hopefully the most common path
-  defp get(pdl, key, :loaded, try_num) do
+  defp get(pdl, key, load_state, try_num) when load_state in [:loaded, :reload] do
     case pdl.backend.get(pdl, key) do
       # if the value was removed from the backend, we should remove it from
       # the load state and try again

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PayDayLoan.Mixfile do
 
   def project do
     [app: :pay_day_loan,
-     version: "0.4.0",
+     version: "0.5.0",
      description: description(),
      package: package(),
      elixir: "~> 1.3",

--- a/test/pay_day_loan/backends/behaviour_test.exs
+++ b/test/pay_day_loan/backends/behaviour_test.exs
@@ -311,4 +311,19 @@ defmodule PayDayLoan.Backends.BehaviourTest do
     # should get cleared from the load state cache
     assert nil == PDL.peek_load_state(Cache.pdl(), key)
   end
+
+  test "reloading does not block" do
+    key = Implementation.key_that_reloads_slowly
+
+    {:ok, v} = Cache.get(key)
+
+    Cache.request_load(key)
+    # if we call this immediately, we should get the old value
+    assert {:ok, v} == Cache.get(key)
+
+    Patiently.wait_for!(fn ->
+      {:ok, v_new} = Cache.get(key)
+      v_new != v
+    end)
+  end
 end

--- a/test/support/test_implementation.ex
+++ b/test/support/test_implementation.ex
@@ -8,6 +8,7 @@ defmodule PayDayLoan.Support.TestImplementation do
 
       @key_that_shall_be_replaced "key that shall be replaced" 
       @key_that_loads_too_slowly "key that loads too slowly"
+      @key_that_reloads_slowly "key that reloads slowly"
       @key_that_does_not_exist "key that does not exist"
       @key_that_will_not_new "key that will not new"
       @key_that_will_not_refresh "key that will not refresh"
@@ -28,6 +29,11 @@ defmodule PayDayLoan.Support.TestImplementation do
       # this one will take too long to load
       def key_that_loads_too_slowly do
         @key_that_loads_too_slowly
+      end
+
+      # this key takes more than one cycle to refresh but does not time out
+      def  key_that_reloads_slowly do
+        @key_that_reloads_slowly
       end
 
       # this one will fail the key cache check
@@ -113,6 +119,11 @@ defmodule PayDayLoan.Support.TestImplementation do
       def refresh(old_value, key = @key_that_shall_be_replaced, value) do
         LoadHistory.refresh(old_value, key, value)
         # replace existing value
+        on_replace(old_value, key, value)
+      end
+      def refresh(old_value, key = @key_that_reloads_slowly, value) do
+        LoadHistory.refresh(old_value, key, value)
+        :timer.sleep(100)
         on_replace(old_value, key, value)
       end
       def refresh(old_value, key, value) do


### PR DESCRIPTION
Consider a key `k` that is already loaded into cache, and suppose we
call `Cache.request_load(k)`.

The existing PDL behavior is to place the key into `:requested` state,
which will block any subsequen `get` requests for that key until it is
loaded.

The behaviour introduced in this PR is to place the key into a `:reload`
state; `get` requests will be non-blocking (returning the already-cached
value) during the reload.  The load worker now prioritizes `:requested`
keys over `:reload` keys.