### PR TITLE
Fix generated typespec, vers bump, only build master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: elixir
 
+branches:
+  only:
+    - "master"
+
 cache:
   directories:
     - deps

--- a/lib/pay_day_loan/cache_generator.ex
+++ b/lib/pay_day_loan/cache_generator.ex
@@ -49,7 +49,7 @@ defmodule PayDayLoan.CacheGenerator do
   defp generate_shortcuts do
     quote location: :keep do
       @doc "Wraps `PayDayLoan.get/2`"
-      @spec get(PayDayLoan.key) :: {:ok, term} | {:error, :not_found}
+      @spec get(PayDayLoan.key) :: {:ok, term} | {:error, PayDayLoan.error}
       def get(key) do
         PayDayLoan.get(pdl(), key)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PayDayLoan.Mixfile do
 
   def project do
     [app: :pay_day_loan,
-     version: "0.5.2",
+     version: "0.5.3",
      description: description(),
      package: package(),
      elixir: "~> 1.3",


### PR DESCRIPTION
* I missed the typepsec in the code generation module.
* Anticipating this being 0.5.3, I version bumped in mix.exs
* Set travis to only build master as a branch (PRs are still built)