### PR TITLE
Made pay_day_loan function overridable

### DIFF
--- a/lib/pay_day_loan/cache_generator.ex
+++ b/lib/pay_day_loan/cache_generator.ex
@@ -39,7 +39,7 @@ defmodule PayDayLoan.CacheGenerator do
       @spec pdl :: PayDayLoan.t
       defdelegate pdl, to: __MODULE__, as: :pay_day_loan
 
-      defoverridable [pdl: 0]
+      defoverridable [pay_day_loan: 0]
     end
   end
 

--- a/lib/pay_day_loan/cache_generator.ex
+++ b/lib/pay_day_loan/cache_generator.ex
@@ -38,6 +38,8 @@ defmodule PayDayLoan.CacheGenerator do
       @doc "Alias of pay_day_loan/0"
       @spec pdl :: PayDayLoan.t
       defdelegate pdl, to: __MODULE__, as: :pay_day_loan
+
+      defoverridable [pdl: 0]
     end
   end
 


### PR DESCRIPTION
Made the pay_day_loan function overridable. The override is intended to be used to set configuration values at runtime. 