### PR TITLE
Concurrent load worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ jobs:
   include:
     - elixir: 1.9.4
       otp_release: 22.3
+    - elixir: 1.8.2
+      otp_release: 22.3
+    - elixir: 1.7.4
+      otp_release: 22.3
+    - elixir: 1.6.6
+      otp_release: 21.3
+    - elixir: 1.5.3
+      otp_release: 20.3
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ elixir:
 
 jobs:
   include:
+    - elixir: 1.10.4
+      otp_release: 23.0
     - elixir: 1.9.4
       otp_release: 22.3
     - elixir: 1.8.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: elixir
 
+otp_release: 
+  - 23.0
+
+elixir:
+  - 1.10.4
+
 branches:
   only:
     - "master"
@@ -10,11 +16,6 @@ cache:
     - _build
     - ~/.mix
     - ~/.hex
-
-matrix:
-  include:
-    - elixir: 1.10.4
-      otp_release: 23.1
 
 script:
   - ./scripts/ci_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ otp_release:
 elixir:
   - 1.10.4
 
+jobs:
+  include:
+    - elixir: 1.9.4
+      otp_release: 22.3
+
 branches:
   only:
     - "master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,8 @@ cache:
 
 matrix:
   include:
-    - elixir: 1.3.4
-      otp_release: 18.3
-      env: COVERALLS=false
-    - elixir: 1.4.5
-      otp_release: 18.3
-      env: COVERALLS=false
-    - elixir: 1.4.5
-      otp_release: 19.2
-      env: COVERALLS=false
-    - elixir: 1.4.5
-      otp_release: 20.2
-      env: COVERALLS=false
-    - elixir: 1.5.3
-      otp_release: 19.2
-      env: COVERALLS=false
-    - elixir: 1.5.3
-      otp_release: 20.2
-      env:
-        COVERALLS=true
-        DIALYZER=true
-    - elixir: 1.6.3
-      otp_release: 20.2
+    - elixir: 1.10.4
+      otp_release: 23.1
 
 script:
   - ./scripts/ci_build.sh

--- a/lib/pay_day_loan.ex
+++ b/lib/pay_day_loan.ex
@@ -18,6 +18,7 @@ defmodule PayDayLoan do
     batch_size: nil,
     load_num_tries: nil,
     load_wait_msec: nil,
+    load_task_supervisor: nil,
     supervisor_name: nil,
     event_loggers: []
   )
@@ -79,6 +80,7 @@ defmodule PayDayLoan do
           batch_size: pos_integer,
           load_num_tries: pos_integer,
           load_wait_msec: pos_integer,
+          load_task_supervisor: atom,
           supervisor_name: atom,
           event_loggers: [event_logger]
         }
@@ -489,6 +491,7 @@ defmodule PayDayLoan do
       backend: PayDayLoan.EtsBackend,
       key_cache: String.to_atom(name <> "_key_cache"),
       load_worker: String.to_atom(name <> "_load_worker"),
+      load_task_supervisor: String.to_atom(name <> "_load_task_supervisor"),
       supervisor_name: String.to_atom(name <> "_supervisor"),
       event_loggers: [],
       batch_size: @default_batch_size,

--- a/lib/pay_day_loan.ex
+++ b/lib/pay_day_loan.ex
@@ -46,7 +46,7 @@ defmodule PayDayLoan do
   A function that takes an `event` and a `key` and performs some logging action.
   The return value is ignored
   """
-  @type event_logger :: ((event, key) -> term)
+  @type event_logger :: (event, key -> term)
 
   @typedoc """
   Struct encapsulating a PDL cache.
@@ -69,19 +69,19 @@ defmodule PayDayLoan do
   * `supervisor_name` - Registration name for the supervisor.
   """
   @type t :: %PayDayLoan{
-    backend_payload: atom,
-    load_state_manager: atom,
-    cache_monitor: atom | false,
-    backend: atom,
-    key_cache: atom,
-    load_worker: atom,
-    callback_module: module,
-    batch_size: pos_integer,
-    load_num_tries: pos_integer,
-    load_wait_msec: pos_integer,
-    supervisor_name: atom,
-    event_loggers: [event_logger]
-  }
+          backend_payload: atom,
+          load_state_manager: atom,
+          cache_monitor: atom | false,
+          backend: atom,
+          key_cache: atom,
+          load_worker: atom,
+          callback_module: module,
+          batch_size: pos_integer,
+          load_num_tries: pos_integer,
+          load_wait_msec: pos_integer,
+          supervisor_name: atom,
+          event_loggers: [event_logger]
+        }
 
   @typedoc """
   Datum returned by the load callback corresponding to a single key.
@@ -137,8 +137,8 @@ defmodule PayDayLoan do
     Note that there is no requirement that each key passed in
     be represented in the output.
     """
-    @callback bulk_load(keys :: [PayDayLoan.key]) ::
-      [{PayDayLoan.key, PayDayLoan.load_datum}]
+    @callback bulk_load(keys :: [PayDayLoan.key()]) ::
+                [{PayDayLoan.key(), PayDayLoan.load_datum()}]
 
     @doc """
     Create a new cache element before sending it to the backend.
@@ -149,8 +149,8 @@ defmodule PayDayLoan do
     just return `{:ok, load_datum}`.  To signal an error which will cause the
     load to fail for this key, return `{:error, <error payload>}`.
     """
-    @callback new(key :: PayDayLoan.key, load_datum :: PayDayLoan.load_datum) ::
-      {:ok, term} | {:error, term} | :ignore
+    @callback new(key :: PayDayLoan.key(), load_datum :: PayDayLoan.load_datum()) ::
+                {:ok, term} | {:error, term} | :ignore
 
     @doc """
     Update a cache element before storing it.
@@ -171,10 +171,10 @@ defmodule PayDayLoan do
     it is requested again.
     """
     @callback refresh(
-      existing_value :: term,
-      key :: PayDayLoan.key,
-      load_datum :: PayDayLoan.load_datum
-    ) :: {:ok, term} | {:error, term} | :ignore
+                existing_value :: term,
+                key :: PayDayLoan.key(),
+                load_datum :: PayDayLoan.load_datum()
+              ) :: {:ok, term} | {:error, term} | :ignore
 
     @doc """
     Should return true if a key exists in the cache's source.  This should be a
@@ -184,7 +184,7 @@ defmodule PayDayLoan do
     You can stub this method to always return true if you want to effectively
     skip key caching.
     """
-    @callback key_exists?(key :: PayDayLoan.key) :: boolean
+    @callback key_exists?(key :: PayDayLoan.key()) :: boolean
   end
 
   defmodule Backend do
@@ -201,7 +201,7 @@ defmodule PayDayLoan do
     Called during supervisor initialization - use this callback to initialize
     your backend if needed.  Must return `:ok`.
     """
-    @callback setup(PayDayLoan.t) :: :ok
+    @callback setup(PayDayLoan.t()) :: :ok
 
     @doc """
     Should execute a reduce operation over the key/value pairs in the cache.
@@ -211,24 +211,25 @@ defmodule PayDayLoan do
     it should operate as `Enum.reduce/3` would when given a map.
     """
     @callback reduce(
-      PayDayLoan.t,
-      acc0 :: term,
-      reducer :: (({PayDayLoan.key, term}, term) -> term)) ::  term
+                PayDayLoan.t(),
+                acc0 :: term,
+                reducer :: ({PayDayLoan.key(), term}, term -> term)
+              ) :: term
 
     @doc """
     Should return the number of keys in the cache
     """
-    @callback size(PayDayLoan.t) :: non_neg_integer
+    @callback size(PayDayLoan.t()) :: non_neg_integer
 
     @doc """
     Should return a list of keys in the cache
     """
-    @callback keys(PayDayLoan.t) :: [PayDayLoan.key]
+    @callback keys(PayDayLoan.t()) :: [PayDayLoan.key()]
 
     @doc """
     Should return a list of values in the cache
     """
-    @callback values(PayDayLoan.t) :: [term]
+    @callback values(PayDayLoan.t()) :: [term]
 
     @doc """
     Retrieve a value from the cache
@@ -236,22 +237,22 @@ defmodule PayDayLoan do
     Should return `{:error, :not_found}` if the value is not found and
     `{:ok, value}` otherwise.
     """
-    @callback get(PayDayLoan.t, PayDayLoan.key)
-    :: {:ok, term} | {:error, PayDayLoan.error}
+    @callback get(PayDayLoan.t(), PayDayLoan.key()) ::
+                {:ok, term} | {:error, PayDayLoan.error()}
 
     @doc """
     Insert a value into the cache
 
     Must return `:ok`
     """
-    @callback put(PayDayLoan.t, PayDayLoan.key, term) :: :ok
+    @callback put(PayDayLoan.t(), PayDayLoan.key(), term) :: :ok
 
     @doc """
     Delete a key from the cache
 
     Must return `:ok`
     """
-    @callback delete(PayDayLoan.t, PayDayLoan.key) :: :ok
+    @callback delete(PayDayLoan.t(), PayDayLoan.key()) :: :ok
   end
 
   alias PayDayLoan.CacheGenerator
@@ -287,10 +288,11 @@ defmodule PayDayLoan do
   @doc """
   Returns a supervisor specification for the given pdl
   """
-  @spec supervisor_specification(pdl :: PayDayLoan.t) :: Supervisor.Spec.spec
+  @spec supervisor_specification(pdl :: PayDayLoan.t()) :: Supervisor.Spec.spec()
   def supervisor_specification(pdl = %PayDayLoan{}) do
-    pdl = pdl
-    |> merge_defaults
+    pdl =
+      pdl
+      |> merge_defaults
 
     Supervisor.Spec.supervisor(
       PayDayLoan.Supervisor,
@@ -310,7 +312,7 @@ defmodule PayDayLoan do
   @doc """
   Check load state, but do not request a load
   """
-  @spec peek_load_state(pdl :: t, key) :: nil | LoadState.t
+  @spec peek_load_state(pdl :: t, key) :: nil | LoadState.t()
   def peek_load_state(pdl = %PayDayLoan{}, key) do
     LoadState.peek(pdl.load_state_manager, key)
   end
@@ -330,9 +332,10 @@ defmodule PayDayLoan do
       reload: 0,
       reload_loading: 0
     }
+
     :ets.foldl(
-      fn({_key, status}, stats_acc) ->
-        Map.update(stats_acc, status, 0, fn(c) -> c + 1 end)
+      fn {_key, status}, stats_acc ->
+        Map.update(stats_acc, status, 0, fn c -> c + 1 end)
       end,
       stats,
       pdl.load_state_manager
@@ -345,7 +348,7 @@ defmodule PayDayLoan do
   Does not ping the load worker.  A load will not happen until
   the next ping.  Use `request_load/2` to request load and trigger a load ping.
   """
-  @spec query_load_state(pdl :: t, key) :: LoadState.t
+  @spec query_load_state(pdl :: t, key) :: LoadState.t()
   def query_load_state(pdl = %PayDayLoan{}, key) do
     LoadState.query(pdl.load_state_manager, key)
   end
@@ -382,7 +385,7 @@ defmodule PayDayLoan do
   @doc """
   Returns a list of all keys in the given cache
   """
-  @spec keys(pdl :: t) :: [PayDayLoan.key]
+  @spec keys(pdl :: t) :: [PayDayLoan.key()]
   def keys(pdl = %PayDayLoan{}) do
     pdl.backend.keys(pdl)
   end
@@ -407,11 +410,12 @@ defmodule PayDayLoan do
   Perform Enum.reduce/3 over all {key, pid} pairs in the given cache
   """
   @spec reduce(
-    pdl :: t,
-    acc0 :: term,
-    reducer :: (({key, pid}, term) -> term)) :: term
+          pdl :: t,
+          acc0 :: term,
+          reducer :: ({key, pid}, term -> term)
+        ) :: term
   def reduce(pdl = %PayDayLoan{}, acc0, reducer)
-  when is_function(reducer, 2) do
+      when is_function(reducer, 2) do
     pdl.backend.reduce(pdl, acc0, reducer)
   end
 
@@ -421,13 +425,13 @@ defmodule PayDayLoan do
   If no value is found, `not_found_callback` is executed.  By default,
   the `not_found_callback` is a function that returns `{:error, :not_found}`.
   """
-  @spec with_value(t, PayDayLoan.key, ((term) -> term), (() -> term)) :: term
+  @spec with_value(t, PayDayLoan.key(), (term -> term), (() -> term)) :: term
   def with_value(
-    pdl,
-    key,
-    found_callback,
-    not_found_callback \\ fn -> {:error, :not_found} end
-  ) do
+        pdl,
+        key,
+        found_callback,
+        not_found_callback \\ fn -> {:error, :not_found} end
+      ) do
     case peek(pdl, key) do
       {:ok, value} -> found_callback.(value)
       {:error, :not_found} -> not_found_callback.()
@@ -445,11 +449,11 @@ defmodule PayDayLoan do
       key,
       fn
         # found with the same value
-        (^value) -> :ok
+        ^value -> :ok
         # found with a different pid
-        (other_value) -> {:error, other_value}
+        other_value -> {:error, other_value}
       end,
-      fn() ->
+      fn ->
         # not found
         _ = LoadState.loaded(pdl.load_state_manager, key)
         _ = KeyCache.add_to_cache(pdl.key_cache, key)
@@ -475,21 +479,21 @@ defmodule PayDayLoan do
   @doc false
   @spec merge_defaults(t) :: t
   def merge_defaults(pdl = %PayDayLoan{callback_module: callback_module})
-  when not is_nil(callback_module) do
+      when not is_nil(callback_module) do
     name = callback_module_to_name_string(callback_module)
 
     defaults = %PayDayLoan{
-      backend_payload:     String.to_atom(name <> "_backend"),
-      load_state_manager:  String.to_atom(name <> "_load_state_manager"),
-      cache_monitor:       String.to_atom(name <> "_cache_monitor"),
-      backend:             PayDayLoan.EtsBackend,
-      key_cache:           String.to_atom(name <> "_key_cache"),
-      load_worker:         String.to_atom(name <> "_load_worker"),
-      supervisor_name:     String.to_atom(name <> "_supervisor"),
-      event_loggers:       [],
-      batch_size:          @default_batch_size,
-      load_num_tries:      @default_load_num_tries,
-      load_wait_msec:      @default_load_wait_msec
+      backend_payload: String.to_atom(name <> "_backend"),
+      load_state_manager: String.to_atom(name <> "_load_state_manager"),
+      cache_monitor: String.to_atom(name <> "_cache_monitor"),
+      backend: PayDayLoan.EtsBackend,
+      key_cache: String.to_atom(name <> "_key_cache"),
+      load_worker: String.to_atom(name <> "_load_worker"),
+      supervisor_name: String.to_atom(name <> "_supervisor"),
+      event_loggers: [],
+      batch_size: @default_batch_size,
+      load_num_tries: @default_load_num_tries,
+      load_wait_msec: @default_load_wait_msec
     }
 
     Map.merge(defaults, pdl, &nil_merge/3)
@@ -499,7 +503,7 @@ defmodule PayDayLoan do
   # ids, etc.
   defp callback_module_to_name_string(callback_module) do
     callback_module
-    |> Macro.underscore
+    |> Macro.underscore()
     |> String.replace("/", "_")
   end
 
@@ -526,10 +530,11 @@ defmodule PayDayLoan do
     event_log(pdl, :timed_out, key)
     {:error, :timed_out}
   end
+
   # if we're already loaded, we just have to grab the pid
   #    this is hopefully the most common path
   defp get(pdl, key, load_state, try_num)
-  when load_state in [:loaded, :reload, :reload_loading] do
+       when load_state in [:loaded, :reload, :reload_loading] do
     case pdl.backend.get(pdl, key) do
       # if the value was removed from the backend, we should remove it from
       # the load state and try again
@@ -537,15 +542,19 @@ defmodule PayDayLoan do
         event_log(pdl, :disappeared, key)
         :ok = LoadState.unload(pdl.load_state_manager, key)
         get(pdl, key, peek_load_state(pdl, key), try_num - 1)
-      {:ok, value} -> {:ok, value}
+
+      {:ok, value} ->
+        {:ok, value}
     end
   end
+
   # if the key is loading, just dwell and try again
   defp get(pdl, key, :loading, try_num) do
     event_log(pdl, :blocked, key)
     :timer.sleep(pdl.load_wait_msec)
     get(pdl, key, peek_load_state(pdl, key), try_num - 1)
   end
+
   # if the key has been requested but isn't loading,
   # ping the load worker to make sure it knows it has
   # work to do and then dwell and try again
@@ -554,6 +563,7 @@ defmodule PayDayLoan do
     # rest is the same as :loading (don't double decrement try_num)
     get(pdl, key, :loading, try_num)
   end
+
   # cache load failed
   # return an error and clear the failure so that we can try again
   defp get(pdl, key, :failed, _try_num) do
@@ -561,6 +571,7 @@ defmodule PayDayLoan do
     LoadState.unload(pdl.load_state_manager, key)
     {:error, :failed}
   end
+
   # load state doesn't know about this key - i.e.,
   # it has not been requested (at least since the last time
   # it cached out)
@@ -581,7 +592,7 @@ defmodule PayDayLoan do
   end
 
   defp event_log(pdl, event, key) do
-    Enum.each(pdl.event_loggers, fn(logger) ->
+    Enum.each(pdl.event_loggers, fn logger ->
       logger.(event, key)
     end)
   end

--- a/lib/pay_day_loan/cache_generator.ex
+++ b/lib/pay_day_loan/cache_generator.ex
@@ -4,17 +4,19 @@ defmodule PayDayLoan.CacheGenerator do
   @moduledoc false
 
   @doc false
-  @spec compile(Keyword.t) :: Macro.t
+  @spec compile(Keyword.t()) :: Macro.t()
   def compile(opts) when is_list(opts) do
-    callback_module = opts
-    |> Keyword.get(:callback_module)
-    |> determine_callback_module
+    callback_module =
+      opts
+      |> Keyword.get(:callback_module)
+      |> determine_callback_module
 
     # build the config struct with defaults overridden by
     # values from opts
-    pdl = opts
-    |> merge_opts(%PayDayLoan{callback_module: callback_module})
-    |> PayDayLoan.merge_defaults
+    pdl =
+      opts
+      |> merge_opts(%PayDayLoan{callback_module: callback_module})
+      |> PayDayLoan.merge_defaults()
 
     quoted_pdl = quoted_struct(pdl)
 
@@ -30,16 +32,16 @@ defmodule PayDayLoan.CacheGenerator do
   defp generate_pdl(quoted_pdl) do
     quote location: :keep do
       @doc "PayDayLoan-generated cache configuration"
-      @spec pay_day_loan :: PayDayLoan.t
+      @spec pay_day_loan :: PayDayLoan.t()
       def pay_day_loan do
         unquote(quoted_pdl)
       end
 
       @doc "Alias of pay_day_loan/0"
-      @spec pdl :: PayDayLoan.t
+      @spec pdl :: PayDayLoan.t()
       defdelegate pdl, to: __MODULE__, as: :pay_day_loan
 
-      defoverridable [pay_day_loan: 0]
+      defoverridable pay_day_loan: 0
     end
   end
 
@@ -51,17 +53,17 @@ defmodule PayDayLoan.CacheGenerator do
   defp generate_shortcuts do
     quote location: :keep do
       @doc "Wraps `PayDayLoan.get/2`"
-      @spec get(PayDayLoan.key) :: {:ok, term} | {:error, PayDayLoan.error}
+      @spec get(PayDayLoan.key()) :: {:ok, term} | {:error, PayDayLoan.error()}
       def get(key) do
         PayDayLoan.get(pdl(), key)
       end
 
       @doc "Wraps `PayDayLoan.peek/2`"
-      @spec peek(PayDayLoan.key) :: {:ok, term} | {:error, :not_found}
+      @spec peek(PayDayLoan.key()) :: {:ok, term} | {:error, :not_found}
       def peek(key), do: PayDayLoan.peek(pdl(), key)
 
       @doc "Wraps `PayDayLoan.peek_load_state/2`"
-      @spec peek_load_state(PayDayLoan.key) :: nil | PayDayLoan.LoadState.t
+      @spec peek_load_state(PayDayLoan.key()) :: nil | PayDayLoan.LoadState.t()
       def peek_load_state(key), do: PayDayLoan.peek_load_state(pdl(), key)
 
       @doc """
@@ -73,26 +75,26 @@ defmodule PayDayLoan.CacheGenerator do
       def load_state_stats, do: PayDayLoan.load_state_stats(pdl())
 
       @doc "Wraps `PayDayLoan.query_load_state/2`"
-      @spec query_load_state(PayDayLoan.key) :: PayDayLoan.LoadState.t
+      @spec query_load_state(PayDayLoan.key()) :: PayDayLoan.LoadState.t()
       def query_load_state(key), do: PayDayLoan.query_load_state(pdl(), key)
 
       @doc "Wraps `PayDayLoan.supervisor_specification/1`"
-      @spec supervisor_specification() :: Supervisor.Spec.spec
+      @spec supervisor_specification() :: Supervisor.Spec.spec()
       def supervisor_specification do
         PayDayLoan.supervisor_specification(pdl())
       end
 
       @doc "Wraps `PayDayLoan.uncache_key/2`"
-      @spec uncache_key(PayDayLoan.key) :: :ok
+      @spec uncache_key(PayDayLoan.key()) :: :ok
       def uncache_key(key), do: PayDayLoan.uncache_key(pdl(), key)
 
       @doc "Wraps `PayDayLoan.with_value/4`"
-      @spec with_value(PayDayLoan.key, ((term) -> term), (() -> term)) :: term
+      @spec with_value(PayDayLoan.key(), (term -> term), (() -> term)) :: term
       def with_value(
-        key,
-        found_callback,
-        not_found_callback \\ fn -> {:error, :not_found} end
-      ) do
+            key,
+            found_callback,
+            not_found_callback \\ fn -> {:error, :not_found} end
+          ) do
         PayDayLoan.with_value(pdl(), key, found_callback, not_found_callback)
       end
 
@@ -103,13 +105,13 @@ defmodule PayDayLoan.CacheGenerator do
       end
 
       @doc "Wraps `PayDayLoan.request_load/2`"
-      @spec request_load(PayDayLoan.key | [PayDayLoan.key]) :: :ok
+      @spec request_load(PayDayLoan.key() | [PayDayLoan.key()]) :: :ok
       def request_load(key_or_keys) do
         PayDayLoan.request_load(pdl(), key_or_keys)
       end
 
       @doc "Wraps `PayDayLoan.keys/1`"
-      @spec keys :: [PayDayLoan.key]
+      @spec keys :: [PayDayLoan.key()]
       def keys do
         PayDayLoan.keys(pdl())
       end
@@ -131,14 +133,14 @@ defmodule PayDayLoan.CacheGenerator do
       end
 
       @doc "Wraps `PayDayLoan.reduce/3`"
-      @spec reduce(term, (({PayDayLoan.key, pid}, term) -> term)) :: term
+      @spec reduce(term, ({PayDayLoan.key(), pid}, term -> term)) :: term
       def reduce(acc0, reducer)
-      when is_function(reducer, 2) do
+          when is_function(reducer, 2) do
         PayDayLoan.reduce(pdl(), acc0, reducer)
       end
 
       @doc "Wraps `PayDayLoan.cache/3`"
-      @spec cache(PayDayLoan.key, pid) :: :ok | {:error, pid}
+      @spec cache(PayDayLoan.key(), pid) :: :ok | {:error, pid}
       def cache(key, pid) do
         PayDayLoan.cache(pdl(), key, pid)
       end
@@ -146,18 +148,22 @@ defmodule PayDayLoan.CacheGenerator do
   end
 
   defp determine_callback_module(nil) do
-    message = "You must supply a callback module.  E.g.,:" <>
-      " `use PayDayLoan, callback_module: MyCacheLoader`"
+    message =
+      "You must supply a callback module.  E.g.,:" <>
+        " `use PayDayLoan, callback_module: MyCacheLoader`"
+
     raise ArgumentError, message: message
   end
+
   defp determine_callback_module({:__aliases__, _meta, module}) do
     Module.concat(module)
   end
 
   defp merge_opts(opts, pdl) do
     opts
-    |> Keyword.delete(:callback_module) # already merged
-    |> Enum.reduce(pdl, fn({k, v}, acc) ->
+    # already merged
+    |> Keyword.delete(:callback_module)
+    |> Enum.reduce(pdl, fn {k, v}, acc ->
       Map.put(acc, k, v)
     end)
   end
@@ -165,12 +171,14 @@ defmodule PayDayLoan.CacheGenerator do
   # turns a struct into a quoted expression
   defp quoted_struct(struct) do
     struct_module = struct.__struct__
+
     meta = {
       :__aliases__,
       [alias: false],
       Enum.map(Module.split(struct_module), &String.to_atom/1)
     }
-    new_kv = struct |> Map.from_struct |> Enum.into([])
+
+    new_kv = struct |> Map.from_struct() |> Enum.into([])
     {:%, [], [meta, {:%{}, [], new_kv}]}
   end
 end

--- a/lib/pay_day_loan/key_cache.ex
+++ b/lib/pay_day_loan/key_cache.ex
@@ -10,10 +10,12 @@ defmodule PayDayLoan.KeyCache do
   @doc false
   @spec create_table(atom) :: :ok
   def create_table(table_id) do
-    _ = :ets.new(
-      table_id,
-      [:set, :public, :named_table, {:read_concurrency, true}]
-    )
+    _ =
+      :ets.new(
+        table_id,
+        [:set, :public, :named_table, {:read_concurrency, true}]
+      )
+
     :ok
   end
 
@@ -23,7 +25,7 @@ defmodule PayDayLoan.KeyCache do
   Calls `callback_module.key_exists?(key)` if the key is not
   already in cache.
   """
-  @spec exist?(atom, module, PayDayLoan.key) :: boolean
+  @spec exist?(atom, module, PayDayLoan.key()) :: boolean
   def exist?(table_id, callback_module, key) do
     in_cache?(table_id, key) || lookup?(table_id, callback_module, key)
   end
@@ -31,7 +33,7 @@ defmodule PayDayLoan.KeyCache do
   @doc """
   Returns true if the key is in cache
   """
-  @spec in_cache?(atom, PayDayLoan.key) :: boolean
+  @spec in_cache?(atom, PayDayLoan.key()) :: boolean
   def in_cache?(table_id, key) do
     :ets.member(table_id, key)
   end
@@ -39,7 +41,7 @@ defmodule PayDayLoan.KeyCache do
   @doc """
   Remove a key from the cache
   """
-  @spec remove(atom, PayDayLoan.key) :: :ok
+  @spec remove(atom, PayDayLoan.key()) :: :ok
   def remove(table_id, key) do
     _ = :ets.delete(table_id, key)
     :ok
@@ -49,7 +51,7 @@ defmodule PayDayLoan.KeyCache do
   Calls `callback_module.key_exists?(key)`, adds key to cache if the
   callback returns true
   """
-  @spec lookup?(atom, module, PayDayLoan.key) :: boolean
+  @spec lookup?(atom, module, PayDayLoan.key()) :: boolean
   def lookup?(table_id, callback_module, key) do
     if callback_module.key_exists?(key) do
       add_to_cache(table_id, key)
@@ -61,7 +63,7 @@ defmodule PayDayLoan.KeyCache do
   @doc """
   Add a key to the cache
   """
-  @spec add_to_cache(atom, PayDayLoan.key) :: boolean
+  @spec add_to_cache(atom, PayDayLoan.key()) :: boolean
   def add_to_cache(table_id, key) do
     :ets.insert(table_id, {key, true})
   end

--- a/lib/pay_day_loan/load_state.ex
+++ b/lib/pay_day_loan/load_state.ex
@@ -20,17 +20,18 @@ defmodule PayDayLoan.LoadState do
   * `:loaded` - The key is loaded in cache.
   * `:failed` - The key attempted a load or refresh and failed.
   """
-  @type t :: :requested | :reload | :loading | :loaded |
-    :failed | :reload_loading
+  @type t :: :requested | :reload | :loading | :loaded | :failed | :reload_loading
 
   # creates the ETS table
   @doc false
   @spec create_table(atom) :: :ok
   def create_table(ets_table_id) do
-    _ = :ets.new(
-      ets_table_id,
-      [:set, :public, :named_table, {:read_concurrency, true}]
-    )
+    _ =
+      :ets.new(
+        ets_table_id,
+        [:set, :public, :named_table, {:read_concurrency, true}]
+      )
+
     :ok
   end
 
@@ -38,14 +39,16 @@ defmodule PayDayLoan.LoadState do
   Set the load state to `:requested` if not loaded or loading,
   return the load state
   """
-  @spec query(atom, PayDayLoan.key | [PayDayLoan.key]) :: t | [t]
+  @spec query(atom, PayDayLoan.key() | [PayDayLoan.key()]) :: t | [t]
   def query(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> query(ets_table_id, key) end)
+    Enum.map(keys, fn key -> query(ets_table_id, key) end)
   end
+
   def query(ets_table_id, key) do
     case :ets.lookup(ets_table_id, key) do
       [] ->
         :requested = request(ets_table_id, key)
+
       [{^key, status}] ->
         status
     end
@@ -54,10 +57,11 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Return load state without modifying; return nil if key is not found
   """
-  @spec peek(atom, PayDayLoan.key | [PayDayLoan.key]) :: t | nil | [t | nil]
+  @spec peek(atom, PayDayLoan.key() | [PayDayLoan.key()]) :: t | nil | [t | nil]
   def peek(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> peek(ets_table_id, key) end)
+    Enum.map(keys, fn key -> peek(ets_table_id, key) end)
   end
+
   def peek(ets_table_id, key) do
     case :ets.lookup(ets_table_id, key) do
       [] -> nil
@@ -68,11 +72,12 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Set state to `:requested`
   """
-  @spec request(atom, PayDayLoan.key | [PayDayLoan.key]) ::
-    :requested | [:requested]
+  @spec request(atom, PayDayLoan.key() | [PayDayLoan.key()]) ::
+          :requested | [:requested]
   def request(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> request(ets_table_id, key) end)
+    Enum.map(keys, fn key -> request(ets_table_id, key) end)
   end
+
   def request(ets_table_id, key) do
     set_status(ets_table_id, key, :requested)
   end
@@ -80,10 +85,11 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Set the state to `:reload`
   """
-  @spec reload(atom, PayDayLoan.key | [PayDayLoan.key]) :: :reload | [:reload]
+  @spec reload(atom, PayDayLoan.key() | [PayDayLoan.key()]) :: :reload | [:reload]
   def reload(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> reload(ets_table_id, key) end)
+    Enum.map(keys, fn key -> reload(ets_table_id, key) end)
   end
+
   def reload(ets_table_id, key) do
     set_status(ets_table_id, key, :reload)
   end
@@ -92,11 +98,12 @@ defmodule PayDayLoan.LoadState do
   Set the state to `:reload` if the key is loaded, set it to `:request` if it
   is not
   """
-  @spec request_or_reload(atom, PayDayLoan.key | [PayDayLoan.key]) ::
-  :request | :reload | [:request | :reload]
+  @spec request_or_reload(atom, PayDayLoan.key() | [PayDayLoan.key()]) ::
+          :request | :reload | [:request | :reload]
   def request_or_reload(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> request_or_reload(ets_table_id, key) end)
+    Enum.map(keys, fn key -> request_or_reload(ets_table_id, key) end)
   end
+
   def request_or_reload(ets_table_id, key) do
     if peek(ets_table_id, key) == :loaded do
       reload(ets_table_id, key)
@@ -108,11 +115,12 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Set state to `:loaded`
   """
-  @spec loaded(atom, PayDayLoan.key | [PayDayLoan.key]) ::
-    :loaded | [:loaded]
+  @spec loaded(atom, PayDayLoan.key() | [PayDayLoan.key()]) ::
+          :loaded | [:loaded]
   def loaded(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> loaded(ets_table_id, key) end)
+    Enum.map(keys, fn key -> loaded(ets_table_id, key) end)
   end
+
   def loaded(ets_table_id, key) do
     set_status(ets_table_id, key, :loaded)
   end
@@ -120,11 +128,12 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Set state to `:loading`
   """
-  @spec loading(atom, PayDayLoan.key | [PayDayLoan.key]) ::
-    :loading | [:loading]
+  @spec loading(atom, PayDayLoan.key() | [PayDayLoan.key()]) ::
+          :loading | [:loading]
   def loading(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> loading(ets_table_id, key) end)
+    Enum.map(keys, fn key -> loading(ets_table_id, key) end)
   end
+
   def loading(ets_table_id, key) do
     set_status(ets_table_id, key, :loading)
   end
@@ -132,11 +141,12 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Set state to `:reload_loading`
   """
-  @spec reload_loading(atom, PayDayLoan.key | [PayDayLoan.key]) ::
-    :reload_loading | [:reload_loading]
+  @spec reload_loading(atom, PayDayLoan.key() | [PayDayLoan.key()]) ::
+          :reload_loading | [:reload_loading]
   def reload_loading(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> reload_loading(ets_table_id, key) end)
+    Enum.map(keys, fn key -> reload_loading(ets_table_id, key) end)
   end
+
   def reload_loading(ets_table_id, key) do
     set_status(ets_table_id, key, :reload_loading)
   end
@@ -144,11 +154,12 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Set state to `:failed`
   """
-  @spec failed(atom, PayDayLoan.key | [PayDayLoan.key]) ::
-    :failed | [:failed]
+  @spec failed(atom, PayDayLoan.key() | [PayDayLoan.key()]) ::
+          :failed | [:failed]
   def failed(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> failed(ets_table_id, key) end)
+    Enum.map(keys, fn key -> failed(ets_table_id, key) end)
   end
+
   def failed(ets_table_id, key) do
     set_status(ets_table_id, key, :failed)
   end
@@ -156,10 +167,11 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Remove a key from the load state table
   """
-  @spec unload(atom, PayDayLoan.key | [PayDayLoan.key]) :: :ok | [:ok]
+  @spec unload(atom, PayDayLoan.key() | [PayDayLoan.key()]) :: :ok | [:ok]
   def unload(ets_table_id, keys) when is_list(keys) do
-    Enum.map(keys, fn(key) -> unload(ets_table_id, key) end)
+    Enum.map(keys, fn key -> unload(ets_table_id, key) end)
   end
+
   def unload(ets_table_id, key) do
     true = :ets.delete(ets_table_id, key)
     :ok
@@ -186,8 +198,9 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Return the list of requested keys, limited to `limit` elements
   """
-  @spec requested_keys(atom, pos_integer) :: [PayDayLoan.key]
+  @spec requested_keys(atom, pos_integer) :: [PayDayLoan.key()]
   def requested_keys(_ets_table_id, 0), do: []
+
   def requested_keys(ets_table_id, limit) do
     keys_in_state(ets_table_id, :requested, limit)
   end
@@ -195,8 +208,9 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Return the list of keys in the `:reload` state, limited to `limit` elements
   """
-  @spec reload_keys(atom, pos_integer) :: [PayDayLoan.key]
+  @spec reload_keys(atom, pos_integer) :: [PayDayLoan.key()]
   def reload_keys(_ets_table_id, 0), do: []
+
   def reload_keys(ets_table_id, limit) do
     keys_in_state(ets_table_id, :reload, limit)
   end
@@ -204,7 +218,7 @@ defmodule PayDayLoan.LoadState do
   @doc """
   Returns all elements of the table
   """
-  @spec all(atom) :: [{PayDayLoan.key, t}]
+  @spec all(atom) :: [{PayDayLoan.key(), t}]
   def all(ets_table_id) do
     List.flatten(:ets.match(ets_table_id, :"$1"))
   end

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -21,8 +21,8 @@ defmodule PayDayLoan.LoadWorker do
   use GenServer
 
   @doc "Start in a supervision tree"
-  @spec start_link(PayDayLoan.t(), GenServer.options()) :: GenServer.on_start()
-  def start_link(init_state = %PayDayLoan{}, gen_server_opts \\ []) do
+  @spec start_link({PayDayLoan.t, GenServer.options}) :: GenServer.on_start
+  def start_link({init_state = %PayDayLoan{}, gen_server_opts}) do
     GenServer.start_link(__MODULE__, [init_state], gen_server_opts)
   end
 

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -32,12 +32,14 @@ defmodule PayDayLoan.LoadWorker do
   end
 
   @spec init([PayDayLoan.t()]) :: {:ok, state}
+  @impl true
   def init([pdl]) do
     Process.send_after(self(), :ping, @startup_dwell)
     {:ok, %{pdl: pdl, load_task_ref: nil}}
   end
 
   @spec handle_cast(atom, state) :: {:noreply, state}
+  @impl true
   def handle_cast(:ping, %{pdl: pdl, load_task_ref: nil} = state) do
     load_task = start_load_task(pdl)
     {:noreply, %{state | load_task_ref: load_task.ref}}
@@ -48,6 +50,7 @@ defmodule PayDayLoan.LoadWorker do
   end
 
   @spec handle_info(atom, state) :: {:noreply, state}
+  @impl true
   def handle_info(:ping, %{pdl: pdl, load_task_ref: nil} = state) do
     load_task = start_load_task(pdl)
     {:noreply, %{state | load_task_ref: load_task.ref}}
@@ -58,12 +61,13 @@ defmodule PayDayLoan.LoadWorker do
   end
 
   @spec handle_info(tuple, state) :: {:noreply, state}
+  @impl true
   def handle_info({ref, :ok}, state) do
     Process.demonitor(ref, [:flush])
     {:noreply, %{state | load_task_ref: nil}}
   end
 
-  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
     {:noreply, %{state | load_task_ref: nil}}
   end
 

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -21,39 +21,41 @@ defmodule PayDayLoan.LoadWorker do
   use GenServer
 
   @doc "Start in a supervision tree"
-  @spec start_link(PayDayLoan.t, GenServer.options) :: GenServer.on_start
+  @spec start_link(PayDayLoan.t(), GenServer.options()) :: GenServer.on_start()
   def start_link(init_state = %PayDayLoan{}, gen_server_opts \\ []) do
     GenServer.start_link(__MODULE__, [init_state], gen_server_opts)
   end
 
-  @spec init([PayDayLoan.t]) :: {:ok, PayDayLoan.t}
+  @spec init([PayDayLoan.t()]) :: {:ok, PayDayLoan.t()}
   def init([pdl]) do
     Process.send_after(self(), :ping, @startup_dwell)
     {:ok, pdl}
   end
 
-  @spec handle_cast(atom, PayDayLoan.t) :: {:noreply, PayDayLoan.t}
+  @spec handle_cast(atom, PayDayLoan.t()) :: {:noreply, PayDayLoan.t()}
   def handle_cast(:ping, pdl) do
     :ok = do_load(pdl, LoadState.any_requested?(pdl.load_state_manager))
     {:noreply, pdl}
   end
 
-  @spec handle_info(atom, PayDayLoan.t) :: {:noreply, PayDayLoan.t}
+  @spec handle_info(atom, PayDayLoan.t()) :: {:noreply, PayDayLoan.t()}
   def handle_info(:ping, pdl) do
     :ok = do_load(pdl, LoadState.any_requested?(pdl.load_state_manager))
     {:noreply, pdl}
   end
 
   defp do_load(_pdl, false), do: :ok
+
   defp do_load(pdl, true) do
-    requested_keys =
-      LoadState.requested_keys(pdl.load_state_manager, pdl.batch_size)
+    requested_keys = LoadState.requested_keys(pdl.load_state_manager, pdl.batch_size)
     _ = LoadState.loading(pdl.load_state_manager, requested_keys)
 
-    reload_keys = LoadState.reload_keys(
-      pdl.load_state_manager,
-      pdl.batch_size - length(requested_keys)
-    )
+    reload_keys =
+      LoadState.reload_keys(
+        pdl.load_state_manager,
+        pdl.batch_size - length(requested_keys)
+      )
+
     _ = LoadState.reload_loading(pdl.load_state_manager, reload_keys)
 
     load_batch(pdl, requested_keys ++ reload_keys)
@@ -69,25 +71,26 @@ defmodule PayDayLoan.LoadWorker do
     # add it to the cache
     #   we need to know which keys did not get handled so that we can
     #   mark them as failed
-    keys_not_loaded = load_data
-    |> Enum.reduce(
-      MapSet.new(batch_keys),
-      fn({key, load_datum}, keys_remaining) ->
-        # load
-        pdl
-        |> load_element(key, load_datum)
-        |> on_load_or_refresh(pdl, key)
+    keys_not_loaded =
+      load_data
+      |> Enum.reduce(
+        MapSet.new(batch_keys),
+        fn {key, load_datum}, keys_remaining ->
+          # load
+          pdl
+          |> load_element(key, load_datum)
+          |> on_load_or_refresh(pdl, key)
 
-        # remove from the set of loading keys
-        MapSet.delete(keys_remaining, key)
-      end
-    )
+          # remove from the set of loading keys
+          MapSet.delete(keys_remaining, key)
+        end
+      )
 
     # mark these keys as failed because we requested them and they did not
     #    get loaded into cache (e.g., the bulk load query did not return data)
     Enum.each(
       keys_not_loaded,
-      fn(key) -> LoadState.failed(pdl.load_state_manager, key) end
+      fn key -> LoadState.failed(pdl.load_state_manager, key) end
     )
   end
 
@@ -96,10 +99,10 @@ defmodule PayDayLoan.LoadWorker do
     PayDayLoan.with_value(
       pdl,
       key,
-      fn(existing_value) ->
+      fn existing_value ->
         pdl.callback_module.refresh(existing_value, key, load_datum)
       end,
-      fn() ->
+      fn ->
         pdl.callback_module.new(key, load_datum)
       end
     )
@@ -111,11 +114,13 @@ defmodule PayDayLoan.LoadWorker do
     _ = KeyCache.add_to_cache(pdl.key_cache, key)
     pdl.backend.put(pdl, key, value)
   end
+
   defp on_load_or_refresh(:ignore, pdl, key) do
     # treat an :ignore the same as a failure to start
     #   - we failed to add this to cache
     on_load_or_refresh({:error, :ignore}, pdl, key)
   end
+
   defp on_load_or_refresh({:error, _}, pdl, key) do
     LoadState.failed(pdl.load_state_manager, key)
     # NOTE the callback should handle failures - we don't need to

--- a/lib/pay_day_loan/process_monitor.ex
+++ b/lib/pay_day_loan/process_monitor.ex
@@ -21,8 +21,8 @@ defmodule PayDayLoan.ProcessMonitor do
 
   # used by the supervisor
   @doc false
-  @spec start_link(PayDayLoan.t(), GenServer.options()) :: GenServer.on_start()
-  def start_link(pdl = %PayDayLoan{}, gen_server_opts \\ []) do
+  @spec start_link({PayDayLoan.t, GenServer.options}) :: GenServer.on_start
+  def start_link({pdl = %PayDayLoan{}, gen_server_opts}) do
     GenServer.start_link(__MODULE__, [pdl], gen_server_opts)
   end
 

--- a/lib/pay_day_loan/process_monitor.ex
+++ b/lib/pay_day_loan/process_monitor.ex
@@ -16,45 +16,47 @@ defmodule PayDayLoan.ProcessMonitor do
     defstruct(pdl: nil, monitors: %{})
     @type t :: %__MODULE__{}
   end
+
   alias PayDayLoan.ProcessMonitor.State
 
   # used by the supervisor
   @doc false
-  @spec start_link(PayDayLoan.t, GenServer.options) :: GenServer.on_start
+  @spec start_link(PayDayLoan.t(), GenServer.options()) :: GenServer.on_start()
   def start_link(pdl = %PayDayLoan{}, gen_server_opts \\ []) do
     GenServer.start_link(__MODULE__, [pdl], gen_server_opts)
   end
 
   ######################################################################
   # GenServer callbacks
-  @spec init([PayDayLoan.t]) :: {:ok, State.t}
+  @spec init([PayDayLoan.t()]) :: {:ok, State.t()}
   def init([pdl]) do
     # monitor all existing pids, clean up if they have died
     #   (could happen when this process restarts)
-    monitors = Enum.reduce(pdl.backend.values(pdl), %{},
-      fn
-        ({_k, pid}, acc) when is_pid(pid) ->
+    monitors =
+      Enum.reduce(pdl.backend.values(pdl), %{}, fn
+        {_k, pid}, acc when is_pid(pid) ->
           if Process.alive?(pid) do
             ensure_monitored(acc, pid)
           else
             pdl.backend.delete_value(pdl, pid)
             Map.delete(acc, pid)
           end
-        (_, acc) -> acc
-      end
-    )
+
+        _, acc ->
+          acc
+      end)
 
     {:ok, %State{pdl: pdl, monitors: monitors}}
   end
 
-  @spec handle_cast({:monitor, pid}, State.t) :: {:noreply, State.t}
+  @spec handle_cast({:monitor, pid}, State.t()) :: {:noreply, State.t()}
   def handle_cast({:monitor, pid}, state) do
     monitors = ensure_monitored(state.monitors, pid)
     {:noreply, %{state | monitors: monitors}}
   end
 
-  @spec handle_info({:DOWN, term, :process, pid, term}, State.t)
-  :: {:noreply, State.t}
+  @spec handle_info({:DOWN, term, :process, pid, term}, State.t()) ::
+          {:noreply, State.t()}
   def handle_info({:DOWN, _, :process, pid, _}, state = %State{pdl: pdl}) do
     pdl.backend.delete_value(pdl, pid)
     monitors = remove_monitor(state.monitors, pid)

--- a/lib/pay_day_loan/supervisor.ex
+++ b/lib/pay_day_loan/supervisor.ex
@@ -28,7 +28,7 @@ defmodule PayDayLoan.Supervisor do
 
     children =
       Enum.reject(
-        [monitor_worker(pdl), load_worker(pdl)],
+        [monitor_worker(pdl), load_worker(pdl), load_task_supervisor(pdl)],
         &(&1 == nil)
       )
 
@@ -43,6 +43,10 @@ defmodule PayDayLoan.Supervisor do
 
   defp load_worker(pdl) do
     {LoadWorker, {pdl, [name: pdl.load_worker]}}
+  end
+
+  defp load_task_supervisor(pdl) do
+    {Task.Supervisor, name: pdl.load_task_supervisor}
   end
 
   defp setup(pdl = %PayDayLoan{}) do

--- a/lib/pay_day_loan/supervisor.ex
+++ b/lib/pay_day_loan/supervisor.ex
@@ -15,25 +15,28 @@ defmodule PayDayLoan.Supervisor do
   alias PayDayLoan.KeyCache
 
   @doc "Start in a supervision tree"
-  @spec start_link(PayDayLoan.t) :: Supervisor.on_start
+  @spec start_link(PayDayLoan.t()) :: Supervisor.on_start()
   def start_link(pdl = %PayDayLoan{}) do
     Supervisor.start_link(__MODULE__, [pdl], name: pdl.supervisor_name)
   end
 
   # Supervisor callback
-  @spec init([PayDayLoan.t]) ::
-  {:ok, {:supervisor.sup_flags, [Supervisor.Spec.spec]}}
+  @spec init([PayDayLoan.t()]) ::
+          {:ok, {:supervisor.sup_flags(), [Supervisor.Spec.spec()]}}
   def init([pdl]) do
     setup(pdl)
 
-    children = Enum.reject(
-      [monitor_worker(pdl), load_worker(pdl)],
-      &(&1 == nil)
-    )
+    children =
+      Enum.reject(
+        [monitor_worker(pdl), load_worker(pdl)],
+        &(&1 == nil)
+      )
+
     supervise(children, strategy: :one_for_one)
   end
 
   defp monitor_worker(%PayDayLoan{cache_monitor: false}), do: nil
+
   defp monitor_worker(pdl) do
     worker(ProcessMonitor, [pdl, [name: pdl.cache_monitor]])
   end

--- a/lib/pay_day_loan/supervisor.ex
+++ b/lib/pay_day_loan/supervisor.ex
@@ -32,17 +32,17 @@ defmodule PayDayLoan.Supervisor do
         &(&1 == nil)
       )
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 
   defp monitor_worker(%PayDayLoan{cache_monitor: false}), do: nil
 
   defp monitor_worker(pdl) do
-    worker(ProcessMonitor, [pdl, [name: pdl.cache_monitor]])
+    {ProcessMonitor, {pdl, [name: pdl.cache_monitor]}}
   end
 
   defp load_worker(pdl) do
-    worker(LoadWorker, [pdl, [name: pdl.load_worker]])
+    {LoadWorker, {pdl, [name: pdl.load_worker]}}
   end
 
   defp setup(pdl = %PayDayLoan{}) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,28 +2,30 @@ defmodule PayDayLoan.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :pay_day_loan,
-     version: "0.5.3",
-     description: description(),
-     package: package(),
-     elixir: "~> 1.3",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: [
-       "coveralls": :test,
-       "coveralls.detail": :test,
-       "coveralls.post": :test,
-       "coveralls.html": :test
-     ],
-     dialyzer: [
-       plt_add_apps: [],
-       ignore_warnings: ".dialyzer_ignore",
-       flags: [:error_handling, :race_conditions]
-     ],
-     elixirc_paths: elixirc_paths(Mix.env),
-     docs: [main: "PayDayLoan"],
-     deps: deps()]
+    [
+      app: :pay_day_loan,
+      version: "0.5.3",
+      description: description(),
+      package: package(),
+      elixir: "~> 1.3",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ],
+      dialyzer: [
+        plt_add_apps: [],
+        ignore_warnings: ".dialyzer_ignore",
+        flags: [:error_handling, :race_conditions]
+      ],
+      elixirc_paths: elixirc_paths(Mix.env()),
+      docs: [main: "PayDayLoan"],
+      deps: deps()
+    ]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule PayDayLoan.Mixfile do
   def project do
     [
       app: :pay_day_loan,
-      version: "0.5.3",
+      version: "0.6.0",
       description: description(),
       package: package(),
-      elixir: "~> 1.3",
+      elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/test/pay_day_loan/backends/behaviour_test.exs
+++ b/test/pay_day_loan/backends/behaviour_test.exs
@@ -7,7 +7,7 @@ defmodule PayDayLoan.Backends.BehaviourTest do
 
   alias PayDayLoanTest.Support.LoadHistory
 
-  #our cache for testing
+  # our cache for testing
   defmodule Cache do
     # we override batch_size here so we can test overrides -
     #   this is not necessary in general use
@@ -29,10 +29,10 @@ defmodule PayDayLoan.Backends.BehaviourTest do
     def setup(_), do: :ok
 
     def reduce(_pdl, acc0, reducer) do
-      Agent.get(__MODULE__, fn(m) -> Enum.reduce(m, acc0, reducer) end)
+      Agent.get(__MODULE__, fn m -> Enum.reduce(m, acc0, reducer) end)
     end
 
-    def size(_pdl), do: Agent.get(__MODULE__, &map_size/1) 
+    def size(_pdl), do: Agent.get(__MODULE__, &map_size/1)
 
     def keys(_pdl), do: Agent.get(__MODULE__, &Map.keys/1)
 
@@ -42,18 +42,18 @@ defmodule PayDayLoan.Backends.BehaviourTest do
     def get(key), do: get(Cache.pdl(), key)
 
     def get(_pdl, key) do
-      case Agent.get(__MODULE__, fn(m) -> Map.get(m, key) end) do
+      case Agent.get(__MODULE__, fn m -> Map.get(m, key) end) do
         nil -> {:error, :not_found}
         v -> {:ok, v}
       end
     end
 
     def put(_pdl, key, val) do
-      Agent.update(__MODULE__, fn(m) -> Map.put(m, key, "V#{val}") end)
+      Agent.update(__MODULE__, fn m -> Map.put(m, key, "V#{val}") end)
     end
 
     def delete(_pdl, key) do
-      Agent.update(__MODULE__, fn(m) -> Map.delete(m, key) end)
+      Agent.update(__MODULE__, fn m -> Map.delete(m, key) end)
     end
   end
 
@@ -106,33 +106,34 @@ defmodule PayDayLoan.Backends.BehaviourTest do
   test "loading happens in bulk" do
     n = 10
 
-    tasks = (1..n)
-    |> Enum.map(fn(ix) ->
-      Task.async(fn ->
-        {:ok, _pid} = Cache.get(ix)
+    tasks =
+      1..n
+      |> Enum.map(fn ix ->
+        Task.async(fn ->
+          {:ok, _pid} = Cache.get(ix)
+        end)
       end)
-    end)
 
-    Enum.each(tasks, fn(task) -> Task.await(task) end)
-    assert n == Cache.size
+    Enum.each(tasks, fn task -> Task.await(task) end)
+    assert n == Cache.size()
 
-    assert length(LoadHistory.bulk_loads) > 0
-    assert n == length(LoadHistory.news)
-    assert 0 == length(LoadHistory.refreshes)
+    assert length(LoadHistory.bulk_loads()) > 0
+    assert n == length(LoadHistory.news())
+    assert 0 == length(LoadHistory.refreshes())
 
-    (1..n)
-    |> Enum.each(fn(ix) ->
+    1..n
+    |> Enum.each(fn ix ->
       assert PDL.KeyCache.in_cache?(Cache.pdl().key_cache, ix)
     end)
   end
 
   test "refreshing a cache element" do
-    replaced_key = Implementation.key_that_shall_be_replaced
+    replaced_key = Implementation.key_that_shall_be_replaced()
 
     assert {:ok, "V1"} == Cache.get(1)
     assert {:ok, "V#{replaced_key}"} == Cache.get(replaced_key)
 
-    news = LoadHistory.news
+    news = LoadHistory.news()
     assert 2 == length(news)
     assert Enum.member?(news, {:new, [1, 1]})
     assert Enum.member?(news, {:new, [replaced_key, replaced_key]})
@@ -142,11 +143,9 @@ defmodule PayDayLoan.Backends.BehaviourTest do
 
     Cache.request_load([1, replaced_key])
 
-    wait_for(
-      fn ->
-        !PDL.LoadState.any_requested?(Cache.pdl().load_state_manager)
-      end
-    )
+    wait_for(fn ->
+      !PDL.LoadState.any_requested?(Cache.pdl().load_state_manager)
+    end)
 
     assert {:ok, "V1"} == Cache.get(1)
     assert {:ok, "V1"} == Backend.get(1)
@@ -154,30 +153,31 @@ defmodule PayDayLoan.Backends.BehaviourTest do
     assert {:ok, "Vreplaced"} == Cache.get(replaced_key)
     assert {:ok, "Vreplaced"} == Backend.get(replaced_key)
 
-    refreshes = LoadHistory.refreshes
+    refreshes = LoadHistory.refreshes()
     assert 2 == length(refreshes)
     assert Enum.member?(refreshes, {:refresh, ["V1", 1, 1]})
+
     assert Enum.member?(
-      refreshes,
-      {:refresh, ["V#{replaced_key}", replaced_key, replaced_key]}
-    )
+             refreshes,
+             {:refresh, ["V#{replaced_key}", replaced_key, replaced_key]}
+           )
   end
 
   test "requesting a key that is in key cache but fails to load" do
-    key = Implementation.key_that_shall_not_be_loaded
+    key = Implementation.key_that_shall_not_be_loaded()
 
     assert {:error, :failed} == Cache.get(key)
-    assert [{:loaded, [key]}] == LoadHistory.loads
+    assert [{:loaded, [key]}] == LoadHistory.loads()
     assert nil == PDL.LoadState.peek(Cache.pdl().load_state_manager, key)
     # we hold onto the knowledge that the key exists
     assert PDL.KeyCache.in_cache?(Cache.pdl().key_cache, key)
   end
 
   test "requesting a key that does not exist" do
-    key = Implementation.key_that_does_not_exist
+    key = Implementation.key_that_does_not_exist()
 
     assert {:error, :not_found} == Cache.get(key)
-    assert [] == LoadHistory.loads
+    assert [] == LoadHistory.loads()
     refute PDL.KeyCache.in_cache?(Cache.pdl().key_cache, key)
   end
 
@@ -187,20 +187,20 @@ defmodule PayDayLoan.Backends.BehaviourTest do
 
     Cache.request_load(keys)
 
-    wait_for(fn -> length(keys) == Cache.size end)
+    wait_for(fn -> length(keys) == Cache.size() end)
 
-    assert length(keys) == Cache.size
+    assert length(keys) == Cache.size()
   end
 
   test "load failures are ignored (should be handled in callback)" do
-    key = Implementation.key_that_will_not_new
+    key = Implementation.key_that_will_not_new()
     assert {:error, :failed} == Cache.get(key)
     # should get cleared from the load state cache
     assert nil == PDL.peek_load_state(Cache.pdl(), key)
   end
 
   test "refresh failures are ignored (should be handled in callback)" do
-    key = Implementation.key_that_will_not_refresh
+    key = Implementation.key_that_will_not_refresh()
 
     # it should load
     {:ok, _value} = Cache.get(key)
@@ -219,36 +219,40 @@ defmodule PayDayLoan.Backends.BehaviourTest do
   test "working with key/value lists" do
     n = 10
 
-    tasks = (1..n)
-    |> Enum.map(fn(ix) ->
-      Task.async(fn ->
-        {:ok, _value} = Cache.get(ix)
+    tasks =
+      1..n
+      |> Enum.map(fn ix ->
+        Task.async(fn ->
+          {:ok, _value} = Cache.get(ix)
+        end)
       end)
-    end)
 
-    Enum.each(tasks, fn(task) -> Task.await(task) end)
-    assert n == Cache.size
+    Enum.each(tasks, fn task -> Task.await(task) end)
+    assert n == Cache.size()
 
     expect_keys = Enum.to_list(1..n)
-    expect_values = Enum.map(expect_keys, fn(k) -> "V#{k}" end)
+    expect_values = Enum.map(expect_keys, fn k -> "V#{k}" end)
 
-    assert MapSet.new(expect_keys) == MapSet.new(Cache.keys)
-    assert MapSet.new(expect_values) == MapSet.new(Cache.values)
+    assert MapSet.new(expect_keys) == MapSet.new(Cache.keys())
+    assert MapSet.new(expect_values) == MapSet.new(Cache.values())
 
-    expect_map = Enum.reduce(expect_keys, %{},
-      fn(k, acc) ->
+    expect_map =
+      Enum.reduce(expect_keys, %{}, fn k, acc ->
         {:ok, value} = Backend.get(k)
         Map.put(acc, k, value)
       end)
-    
-    got_map = Cache.reduce(%{},
-      fn({k, value}, acc) -> Map.put(acc, k, value) end)
+
+    got_map =
+      Cache.reduce(
+        %{},
+        fn {k, value}, acc -> Map.put(acc, k, value) end
+      )
 
     assert expect_map == got_map
   end
 
   test "when a value is removed from the backend, its key is unloaded" do
-    key = Implementation.key_that_is_removed_from_backend
+    key = Implementation.key_that_is_removed_from_backend()
     {:ok, v1} = Cache.get(key)
 
     assert {:ok, v1} == Backend.get(key)
@@ -265,8 +269,8 @@ defmodule PayDayLoan.Backends.BehaviourTest do
   test "manually adding an element to the cache" do
     Backend.put(Cache.pdl(), 1, 42)
 
-    assert [1] == Cache.keys
-    assert ["V42"] == Cache.values
+    assert [1] == Cache.keys()
+    assert ["V42"] == Cache.values()
     assert {:ok, "V42"} == Backend.get(1)
 
     # this frontend isn't configured to check the backend before inserting
@@ -281,22 +285,22 @@ defmodule PayDayLoan.Backends.BehaviourTest do
 
     :ok = PayDayLoan.uncache_key(Cache.pdl(), 1)
 
-    assert [] == Cache.keys
-    assert [] == Cache.values
+    assert [] == Cache.keys()
+    assert [] == Cache.values()
 
     # we make the callthrough to the backend, so it is also removed from there
     assert {:error, :not_found} == Backend.get(1)
   end
 
   test "when new returns :ignore" do
-    key = Implementation.key_that_returns_ignore_on_new
+    key = Implementation.key_that_returns_ignore_on_new()
     assert {:error, :failed} == Cache.get(key)
     # should get cleared from the load state cache
     assert nil == PDL.peek_load_state(Cache.pdl(), key)
   end
 
   test "refresh :ignore failures are ignored (should be handled in callback)" do
-    key = Implementation.key_that_returns_ignore_on_refresh
+    key = Implementation.key_that_returns_ignore_on_refresh()
 
     # it should load
     {:ok, _v} = Cache.get(key)
@@ -313,7 +317,7 @@ defmodule PayDayLoan.Backends.BehaviourTest do
   end
 
   test "reloading does not block" do
-    key = Implementation.key_that_reloads_slowly
+    key = Implementation.key_that_reloads_slowly()
 
     {:ok, v} = Cache.get(key)
 
@@ -325,7 +329,8 @@ defmodule PayDayLoan.Backends.BehaviourTest do
       {:ok, v_new} = Cache.get(key)
       v_new != v
     end)
+
     assert :loaded == Cache.peek_load_state(key)
-    assert 1 == Cache.size
+    assert 1 == Cache.size()
   end
 end

--- a/test/pay_day_loan/backends/generic_test.exs
+++ b/test/pay_day_loan/backends/generic_test.exs
@@ -13,11 +13,11 @@ defmodule PayDayLoan.Backends.GenericTest do
     end
 
     def log(event, key) do
-      Agent.update(__MODULE__, fn(l) -> [{event, key} | l] end)
+      Agent.update(__MODULE__, fn l -> [{event, key} | l] end)
     end
 
     def logs do
-      Agent.get(__MODULE__, &(&1))
+      Agent.get(__MODULE__, & &1)
     end
   end
 
@@ -27,18 +27,18 @@ defmodule PayDayLoan.Backends.GenericTest do
     end
 
     def get(key) do
-      case Agent.get(__MODULE__, fn(m) -> Map.get(m, key) end) do
+      case Agent.get(__MODULE__, fn m -> Map.get(m, key) end) do
         nil -> {:error, :not_found}
         value -> {:ok, value}
       end
     end
 
     def put(key, value) do
-      Agent.update(__MODULE__, fn(m) -> Map.put(m, key, "V#{value}") end)
+      Agent.update(__MODULE__, fn m -> Map.put(m, key, "V#{value}") end)
     end
 
     def delete(key) do
-      Agent.update(__MODULE__, fn(m) -> Map.delete(m, key) end)
+      Agent.update(__MODULE__, fn m -> Map.delete(m, key) end)
     end
   end
 
@@ -66,7 +66,7 @@ defmodule PayDayLoan.Backends.GenericTest do
     end
   end
 
-  #our cache for testing
+  # our cache for testing
   defmodule Cache do
     # we override batch_size here so we can test overrides -
     #   this is not necessary in general use
@@ -78,7 +78,6 @@ defmodule PayDayLoan.Backends.GenericTest do
       callback_module: PayDayLoan.Backends.GenericTest.Implementation
     )
   end
-
 
   use PayDayLoan.Support.CommonTests, cache: Cache
 
@@ -104,48 +103,55 @@ defmodule PayDayLoan.Backends.GenericTest do
     assert get_result == PDL.peek(Cache.pdl(), key)
 
     assert PDL.KeyCache.in_cache?(Cache.pdl().key_cache, key)
-    assert [] == CacheLogger.logs
+    assert [] == CacheLogger.logs()
 
     assert %{
-      requested: 0, loaded: 1, loading: 0, failed: 0, reload: 0, reload_loading: 0
-    } == Cache.load_state_stats()
+             requested: 0,
+             loaded: 1,
+             loading: 0,
+             failed: 0,
+             reload: 0,
+             reload_loading: 0
+           } == Cache.load_state_stats()
   end
 
   test "loading happens in bulk" do
     n = 10
 
-    tasks = (1..n)
-    |> Enum.map(fn(ix) ->
-      Task.async(fn ->
-        {:ok, _pid} = Cache.get(ix)
+    tasks =
+      1..n
+      |> Enum.map(fn ix ->
+        Task.async(fn ->
+          {:ok, _pid} = Cache.get(ix)
+        end)
       end)
-    end)
 
-    Enum.each(tasks, fn(task) -> Task.await(task) end)
-    assert n == Cache.size
+    Enum.each(tasks, fn task -> Task.await(task) end)
+    assert n == Cache.size()
 
-    assert length(LoadHistory.bulk_loads) > 0
-    assert n == length(LoadHistory.news)
-    assert 0 == length(LoadHistory.refreshes)
+    assert length(LoadHistory.bulk_loads()) > 0
+    assert n == length(LoadHistory.news())
+    assert 0 == length(LoadHistory.refreshes())
 
-    (1..n)
-    |> Enum.each(fn(ix) ->
+    1..n
+    |> Enum.each(fn ix ->
       assert PDL.KeyCache.in_cache?(Cache.pdl().key_cache, ix)
     end)
 
-    assert n == length(CacheLogger.logs)
+    assert n == length(CacheLogger.logs())
+
     for ix <- 1..n do
-      assert {:cache_miss, ix} in CacheLogger.logs
+      assert {:cache_miss, ix} in CacheLogger.logs()
     end
   end
 
   test "refreshing a cache element" do
-    replaced_key = Implementation.key_that_shall_be_replaced
+    replaced_key = Implementation.key_that_shall_be_replaced()
 
     assert {:ok, "V1"} == Cache.get(1)
     assert {:ok, "V#{replaced_key}"} == Cache.get(replaced_key)
 
-    news = LoadHistory.news
+    news = LoadHistory.news()
     assert 2 == length(news)
     assert Enum.member?(news, {:new, [1, 1]})
     assert Enum.member?(news, {:new, [replaced_key, replaced_key]})
@@ -155,11 +161,9 @@ defmodule PayDayLoan.Backends.GenericTest do
 
     Cache.request_load([1, replaced_key])
 
-    wait_for(
-      fn ->
-        !PDL.LoadState.any_requested?(Cache.pdl().load_state_manager)
-      end
-    )
+    wait_for(fn ->
+      !PDL.LoadState.any_requested?(Cache.pdl().load_state_manager)
+    end)
 
     assert {:ok, "V1"} == Cache.get(1)
     assert {:ok, "V1"} == CacheBackend.get(1)
@@ -167,37 +171,38 @@ defmodule PayDayLoan.Backends.GenericTest do
     assert {:ok, "Vreplaced"} == Cache.get(replaced_key)
     assert {:ok, "Vreplaced"} == CacheBackend.get(replaced_key)
 
-    refreshes = LoadHistory.refreshes
+    refreshes = LoadHistory.refreshes()
     assert 2 == length(refreshes)
     assert Enum.member?(refreshes, {:refresh, ["V1", 1, 1]})
-    assert Enum.member?(
-      refreshes,
-      {:refresh, ["V#{replaced_key}", replaced_key, replaced_key]}
-    )
 
-    assert [cache_miss: replaced_key, cache_miss: 1] == CacheLogger.logs
+    assert Enum.member?(
+             refreshes,
+             {:refresh, ["V#{replaced_key}", replaced_key, replaced_key]}
+           )
+
+    assert [cache_miss: replaced_key, cache_miss: 1] == CacheLogger.logs()
   end
 
   test "requesting a key that is in key cache but fails to load" do
-    key = Implementation.key_that_shall_not_be_loaded
+    key = Implementation.key_that_shall_not_be_loaded()
 
     assert {:error, :failed} == Cache.get(key)
-    assert [{:loaded, [key]}] == LoadHistory.loads
+    assert [{:loaded, [key]}] == LoadHistory.loads()
     assert nil == PDL.LoadState.peek(Cache.pdl().load_state_manager, key)
     # we hold onto the knowledge that the key exists
     assert PDL.KeyCache.in_cache?(Cache.pdl().key_cache, key)
 
-    assert [failed: key, cache_miss: key] == CacheLogger.logs
+    assert [failed: key, cache_miss: key] == CacheLogger.logs()
   end
 
   test "requesting a key that does not exist" do
-    key = Implementation.key_that_does_not_exist
+    key = Implementation.key_that_does_not_exist()
 
     assert {:error, :not_found} == Cache.get(key)
-    assert [] == LoadHistory.loads
+    assert [] == LoadHistory.loads()
     refute PDL.KeyCache.in_cache?(Cache.pdl().key_cache, key)
 
-    assert [no_key: key] == CacheLogger.logs
+    assert [no_key: key] == CacheLogger.logs()
   end
 
   test "large batches don't require an extra ping" do
@@ -206,22 +211,22 @@ defmodule PayDayLoan.Backends.GenericTest do
 
     Cache.request_load(keys)
 
-    wait_for(fn -> length(keys) == Cache.size end)
+    wait_for(fn -> length(keys) == Cache.size() end)
 
-    assert length(keys) == Cache.size
+    assert length(keys) == Cache.size()
   end
 
   test "load failures are ignored (should be handled in callback)" do
-    key = Implementation.key_that_will_not_new
+    key = Implementation.key_that_will_not_new()
     assert {:error, :failed} == Cache.get(key)
     # should get cleared from the load state cache
     assert nil == PDL.peek_load_state(Cache.pdl(), key)
 
-    assert [failed: key, cache_miss: key] == CacheLogger.logs
+    assert [failed: key, cache_miss: key] == CacheLogger.logs()
   end
 
   test "refresh failures are ignored (should be handled in callback)" do
-    key = Implementation.key_that_will_not_refresh
+    key = Implementation.key_that_will_not_refresh()
 
     # it should load
     {:ok, _value} = Cache.get(key)
@@ -236,42 +241,46 @@ defmodule PayDayLoan.Backends.GenericTest do
     # should get cleared from the load state cache
     assert nil == PDL.peek_load_state(Cache.pdl(), key)
 
-    assert [failed: key, cache_miss: key] == CacheLogger.logs
+    assert [failed: key, cache_miss: key] == CacheLogger.logs()
   end
 
   test "working with key/value lists" do
     n = 10
 
-    tasks = (1..n)
-    |> Enum.map(fn(ix) ->
-      Task.async(fn ->
-        {:ok, _value} = Cache.get(ix)
+    tasks =
+      1..n
+      |> Enum.map(fn ix ->
+        Task.async(fn ->
+          {:ok, _value} = Cache.get(ix)
+        end)
       end)
-    end)
 
-    Enum.each(tasks, fn(task) -> Task.await(task) end)
-    assert n == Cache.size
+    Enum.each(tasks, fn task -> Task.await(task) end)
+    assert n == Cache.size()
 
     expect_keys = Enum.to_list(1..n)
-    expect_values = Enum.map(expect_keys, fn(k) -> "V#{k}" end)
+    expect_values = Enum.map(expect_keys, fn k -> "V#{k}" end)
 
-    assert MapSet.new(expect_keys) == MapSet.new(Cache.keys)
-    assert MapSet.new(expect_values) == MapSet.new(Cache.values)
+    assert MapSet.new(expect_keys) == MapSet.new(Cache.keys())
+    assert MapSet.new(expect_values) == MapSet.new(Cache.values())
 
-    expect_map = Enum.reduce(expect_keys, %{},
-      fn(k, acc) ->
+    expect_map =
+      Enum.reduce(expect_keys, %{}, fn k, acc ->
         {:ok, value} = CacheBackend.get(k)
         Map.put(acc, k, value)
       end)
-    
-    got_map = Cache.reduce(%{},
-      fn({k, value}, acc) -> Map.put(acc, k, value) end)
+
+    got_map =
+      Cache.reduce(
+        %{},
+        fn {k, value}, acc -> Map.put(acc, k, value) end
+      )
 
     assert expect_map == got_map
   end
 
   test "when a value is removed from the backend, its key is unloaded" do
-    key = Implementation.key_that_is_removed_from_backend
+    key = Implementation.key_that_is_removed_from_backend()
     {:ok, v1} = Cache.get(key)
 
     assert {:ok, v1} == CacheBackend.get(key)
@@ -297,7 +306,8 @@ defmodule PayDayLoan.Backends.GenericTest do
       cache_miss: 2,
       cache_miss: key
     ]
-    assert expect_logs == CacheLogger.logs
+
+    assert expect_logs == CacheLogger.logs()
   end
 
   test "when the monitor is killed, it restarts" do
@@ -323,15 +333,15 @@ defmodule PayDayLoan.Backends.GenericTest do
     CacheBackend.put(1, 42)
     Cache.cache(1, &CacheBackend.get/1)
 
-    assert [1] == Cache.keys
-    assert ["V42"] == Cache.values
+    assert [1] == Cache.keys()
+    assert ["V42"] == Cache.values()
 
     assert {:ok, "V42"} == Cache.get(1)
 
     # can't be manually overwritten
     assert {:error, "V42"} == Cache.cache(1, 0)
 
-    assert [] == CacheLogger.logs
+    assert [] == CacheLogger.logs()
   end
 
   test "manually removing an element from the cache" do
@@ -341,26 +351,26 @@ defmodule PayDayLoan.Backends.GenericTest do
 
     :ok = PayDayLoan.uncache_key(Cache.pdl(), 1)
 
-    assert [] == Cache.keys
-    assert [] == Cache.values
+    assert [] == Cache.keys()
+    assert [] == Cache.values()
 
     # value is still in the backend
     assert {:ok, "V1"} == CacheBackend.get(1)
 
-    assert [cache_miss: 1] == CacheLogger.logs
+    assert [cache_miss: 1] == CacheLogger.logs()
   end
 
   test "when new returns :ignore" do
-    key = Implementation.key_that_returns_ignore_on_new
+    key = Implementation.key_that_returns_ignore_on_new()
     assert {:error, :failed} == Cache.get(key)
     # should get cleared from the load state cache
     assert nil == PDL.peek_load_state(Cache.pdl(), key)
 
-    assert [failed: key, cache_miss: key] == CacheLogger.logs
+    assert [failed: key, cache_miss: key] == CacheLogger.logs()
   end
 
   test "refresh :ignore failures are ignored (should be handled in callback)" do
-    key = Implementation.key_that_returns_ignore_on_refresh
+    key = Implementation.key_that_returns_ignore_on_refresh()
 
     # it should load
     {:ok, _v} = Cache.get(key)
@@ -375,39 +385,46 @@ defmodule PayDayLoan.Backends.GenericTest do
     # should get cleared from the load state cache
     assert nil == PDL.peek_load_state(Cache.pdl(), key)
 
-    assert [failed: key, cache_miss: key] == CacheLogger.logs
+    assert [failed: key, cache_miss: key] == CacheLogger.logs()
   end
 
   test "when a key fails to load before the timeout" do
-    key = Implementation.key_that_loads_too_slowly
+    key = Implementation.key_that_loads_too_slowly()
 
     assert {:error, :timed_out} == Cache.get(key)
 
     assert [timed_out: key, blocked: key, cache_miss: key] ==
-      Enum.uniq(CacheLogger.logs)
+             Enum.uniq(CacheLogger.logs())
   end
 
   test "working with the load state for lists of keys" do
     assert [:requested] ==
-      PDL.LoadState.query(Cache.pdl().load_state_manager, [1])
+             PDL.LoadState.query(Cache.pdl().load_state_manager, [1])
+
     assert [:requested, nil] ==
-      PDL.LoadState.peek(Cache.pdl().load_state_manager, [1, 2])
-    assert [:loaded] == 
-      PDL.LoadState.loaded(Cache.pdl().load_state_manager, [2])
-    assert [:failed] == 
-      PDL.LoadState.failed(Cache.pdl().load_state_manager, [1])
+             PDL.LoadState.peek(Cache.pdl().load_state_manager, [1, 2])
+
+    assert [:loaded] ==
+             PDL.LoadState.loaded(Cache.pdl().load_state_manager, [2])
+
+    assert [:failed] ==
+             PDL.LoadState.failed(Cache.pdl().load_state_manager, [1])
   end
 
   test "cache generator exports all of the desired shortcut functions" do
     base_functions = PayDayLoan.__info__(:functions)
-    wanted_functions = Enum.reject(
-      base_functions,
-      fn({f, _}) ->
-        Enum.member?([:__struct__, :merge_defaults], f)
-      end)
+
+    wanted_functions =
+      Enum.reject(
+        base_functions,
+        fn {f, _} ->
+          Enum.member?([:__struct__, :merge_defaults], f)
+        end
+      )
+
     for {f, arity} <- wanted_functions do
       assert :erlang.function_exported(Cache, f, arity - 1),
-        "Function #{inspect f} not exported"
+             "Function #{inspect(f)} not exported"
     end
   end
 end

--- a/test/support/common_tests.ex
+++ b/test/support/common_tests.ex
@@ -3,25 +3,27 @@ defmodule PayDayLoan.Support.CommonTests do
 
   defmacro __using__(opts \\ []) do
     cache = opts[:cache]
+
     quote location: :keep do
       import PayDayLoanTest.Support, only: [wait_for: 1]
 
       setup do
-        LoadHistory.start
-    
+        LoadHistory.start()
+
         wait_for(fn -> Process.whereis(PDLTestSup) == nil end)
         sup_spec = PayDayLoan.supervisor_specification(unquote(cache).pdl())
-    
-        {:ok, _sup_pid} = Supervisor.start_link(
-          [sup_spec],
-          strategy: :one_for_one,
-          name: PDLTestSup
-        )
-    
-        on_exit fn ->
-          LoadHistory.stop
-        end
-    
+
+        {:ok, _sup_pid} =
+          Supervisor.start_link(
+            [sup_spec],
+            strategy: :one_for_one,
+            name: PDLTestSup
+          )
+
+        on_exit(fn ->
+          LoadHistory.stop()
+        end)
+
         :ok
       end
     end

--- a/test/support/load_history.ex
+++ b/test/support/load_history.ex
@@ -10,6 +10,7 @@ defmodule PayDayLoanTest.Support.LoadHistory do
   end
 
   def loaded([]), do: :ok
+
   def loaded(keys) do
     append({:loaded, keys})
     :ok
@@ -26,7 +27,7 @@ defmodule PayDayLoanTest.Support.LoadHistory do
   end
 
   def get do
-    Agent.get(__MODULE__, fn(x) -> x end)
+    Agent.get(__MODULE__, fn x -> x end)
   end
 
   def bulk_loads do
@@ -50,19 +51,21 @@ defmodule PayDayLoanTest.Support.LoadHistory do
   end
 
   defp append(value) do
-    Agent.update(__MODULE__, fn(so_far) -> so_far ++ [value] end)
+    Agent.update(__MODULE__, fn so_far -> so_far ++ [value] end)
   end
 
   defp is_bulk_load?({:loaded, keys})
-  when is_list(keys) and length(keys) > 1 do
+       when is_list(keys) and length(keys) > 1 do
     true
   end
+
   defp is_bulk_load?(_), do: false
 
   defp is_load?({:loaded, keys})
-  when is_list(keys) and length(keys) > 0 do
+       when is_list(keys) and length(keys) > 0 do
     true
   end
+
   defp is_load?(_), do: false
 
   defp is_new?({:new, _}), do: true
@@ -71,4 +74,3 @@ defmodule PayDayLoanTest.Support.LoadHistory do
   defp is_refresh?({:refresh, _}), do: true
   defp is_refresh?(_), do: false
 end
-

--- a/test/support/test_implementation.ex
+++ b/test/support/test_implementation.ex
@@ -6,7 +6,7 @@ defmodule PayDayLoan.Support.TestImplementation do
     quote do
       @behaviour PayDayLoan.Loader
 
-      @key_that_shall_be_replaced "key that shall be replaced" 
+      @key_that_shall_be_replaced "key that shall be replaced"
       @key_that_loads_too_slowly "key that loads too slowly"
       @key_that_reloads_slowly "key that reloads slowly"
       @key_that_does_not_exist "key that does not exist"
@@ -32,7 +32,7 @@ defmodule PayDayLoan.Support.TestImplementation do
       end
 
       # this key takes more than one cycle to refresh but does not time out
-      def  key_that_reloads_slowly do
+      def key_that_reloads_slowly do
         @key_that_reloads_slowly
       end
 
@@ -70,35 +70,40 @@ defmodule PayDayLoan.Support.TestImplementation do
       def bulk_load(keys) do
         LoadHistory.loaded(keys)
 
-        keys = keys
-               |> Enum.filter(fn(k) ->
-                 k != key_that_shall_not_be_loaded()
-               end)
+        keys =
+          keys
+          |> Enum.filter(fn k ->
+            k != key_that_shall_not_be_loaded()
+          end)
 
-        Enum.map(keys, fn(key) -> {key, key} end)
+        Enum.map(keys, fn key -> {key, key} end)
       end
 
       def new(key = @key_that_will_not_new, value) do
         LoadHistory.new(key, value)
         {:error, :load_failed}
       end
+
       def new(key = @key_that_loads_too_slowly, value) do
         LoadHistory.new(key, value)
         :timer.sleep(500)
         {:error, :load_failed}
       end
+
       def new(key = @key_that_returns_ignore_on_new, value) do
         LoadHistory.new(key, value)
         :ignore
       end
+
       def new(key = @key_that_is_removed_from_backend, value) do
-        if LoadHistory.news == [] do
+        if LoadHistory.news() == [] do
           LoadHistory.new(key, value)
           on_new(key, value)
         else
           {:error, :load_failed}
         end
       end
+
       def new(key, value) do
         LoadHistory.new(key, value)
         on_new(key, value)
@@ -110,22 +115,26 @@ defmodule PayDayLoan.Support.TestImplementation do
         # return error
         {:error, :refresh_failed}
       end
+
       def refresh(old_value, key = @key_that_returns_ignore_on_refresh, value) do
         LoadHistory.refresh(old_value, key, value)
         on_remove(key, old_value)
         # return ignore
         :ignore
       end
+
       def refresh(old_value, key = @key_that_shall_be_replaced, value) do
         LoadHistory.refresh(old_value, key, value)
         # replace existing value
         on_replace(old_value, key, value)
       end
+
       def refresh(old_value, key = @key_that_reloads_slowly, value) do
         LoadHistory.refresh(old_value, key, value)
         :timer.sleep(100)
         on_replace(old_value, key, value)
       end
+
       def refresh(old_value, key, value) do
         LoadHistory.refresh(old_value, key, value)
         on_update(old_value, key, value)


### PR DESCRIPTION
This change is to make the process of loading data from it source happen concurrently to the load_worker so that the load_worker can handle messages while data is being loaded.

The first two commits are formatting and removing deprecated function calls. The third commit is the concurrency changes as well as one optimization by removing the call to the function `any_requested?`.