### PR TITLE
Updated process test for concurrent load worker

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PayDayLoan.Mixfile do
   def project do
     [
       app: :pay_day_loan,
-      version: "0.6.0",
+      version: "0.6.1",
       description: description(),
       package: package(),
       elixir: "~> 1.5",

--- a/test/pay_day_loan/backends/process_test.exs
+++ b/test/pay_day_loan/backends/process_test.exs
@@ -107,7 +107,7 @@ defmodule PayDayLoan.Backends.ProcessTest do
     Cache.request_load([1, replaced_key])
 
     wait_for(fn ->
-      !PDL.LoadState.any_requested?(Cache.pdl().load_state_manager)
+      PDL.peek_load_state(Cache.pdl(), 1) == :loaded && PDL.peek_load_state(Cache.pdl(), replaced_key) == :loaded
     end)
 
     assert {:ok, pid1} == Cache.get(1)


### PR DESCRIPTION
The test for refreshing a cached process was waiting for the load state of the test process to change from :requested or :reload and was not waiting for actual load process to complete and change the state from :requested/:reloaded to :loading/:reload_loading and finally to :loaded. The test was failing because the load task had not yet completed and changed the load state to :loaded. Therefore, I've updated the test to wait until the load state of the test process have changed to :loaded.