### PR TITLE
Fix dialyzer warning

### DIFF
--- a/lib/pay_day_loan/cache_generator.ex
+++ b/lib/pay_day_loan/cache_generator.ex
@@ -79,7 +79,7 @@ defmodule PayDayLoan.CacheGenerator do
       def query_load_state(key), do: PayDayLoan.query_load_state(pdl(), key)
 
       @doc "Wraps `PayDayLoan.supervisor_specification/1`"
-      @spec supervisor_specification() :: Supervisor.Spec.spec()
+      @spec supervisor_specification() :: Supervisor.child_spec()
       def supervisor_specification do
         PayDayLoan.supervisor_specification(pdl())
       end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PayDayLoan.Mixfile do
   def project do
     [
       app: :pay_day_loan,
-      version: "0.7.0",
+      version: "0.7.1",
       description: description(),
       package: package(),
       elixir: "~> 1.7",


### PR DESCRIPTION
Last release missed the cache generator spec, which causes dialyzer to
fail in applications that use PDL.