### PR TITLE
Fix pay day loan getting stuck in :loading when we hit a timeout

### DIFF
--- a/lib/pay_day_loan/load_state.ex
+++ b/lib/pay_day_loan/load_state.ex
@@ -216,6 +216,22 @@ defmodule PayDayLoan.LoadState do
   end
 
   @doc """
+  Return the list of keys in the `:loading` state
+  """
+  @spec loading_keys(atom | :ets.tid()) :: [PayDayLoan.key()]
+  def loading_keys(ets_table_id) do
+    keys_in_state(ets_table_id, :loading)
+  end
+
+  @doc """
+  Return the list of keys in the `:reload_loading` state
+  """
+  @spec reload_loading_keys(atom | :ets.tid()) :: [PayDayLoan.key()]
+  def reload_loading_keys(ets_table_id) do
+    keys_in_state(ets_table_id, :reload_loading)
+  end
+
+  @doc """
   Returns all elements of the table
   """
   @spec all(atom) :: [{PayDayLoan.key(), t}]
@@ -226,6 +242,12 @@ defmodule PayDayLoan.LoadState do
   defp set_status(ets_table_id, key, status) do
     true = :ets.insert(ets_table_id, {key, status})
     status
+  end
+
+  defp keys_in_state(ets_table_id, state) do
+    ets_table_id
+    |> :ets.match({:"$1", state})
+    |> List.flatten()
   end
 
   defp keys_in_state(ets_table_id, state, limit) do

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -71,11 +71,15 @@ defmodule PayDayLoan.LoadWorker do
     # The loader process died, so reset the status of any keys that were in the :loading
     # or :request_loading states to unloaded.
 
-    pending_keys =
-      LoadState.loading_keys(pdl.load_state_manager) ++
-        LoadState.reload_loading_keys(pdl.load_state_manager)
+    LoadState.unload(
+      pdl.load_state_manager,
+      LoadState.loading_keys(pdl.load_state_manager)
+    )
 
-    LoadState.unload(pdl.load_state_manager, pending_keys)
+    LoadState.unload(
+      pdl.load_state_manager,
+      LoadState.reload_loading_keys(pdl.load_state_manager)
+    )
 
     {:noreply, %{state | load_task_ref: nil}}
   end

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -67,7 +67,19 @@ defmodule PayDayLoan.LoadWorker do
     {:noreply, %{state | load_task_ref: nil}}
   end
 
-  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, %{pdl: pdl} = state) do
+    # The loader process died, so reset the status of any keys that were in the :loading
+    # or :request_loading states to unloaded.
+    LoadState.unload(
+      pdl.load_state_manager,
+      LoadState.loading_keys(pdl.load_state_manager)
+    )
+
+    LoadState.unload(
+      pdl.load_state_manager,
+      LoadState.reload_loading_keys(pdl.load_state_manager)
+    )
+
     {:noreply, %{state | load_task_ref: nil}}
   end
 

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -70,15 +70,11 @@ defmodule PayDayLoan.LoadWorker do
   def handle_info({:DOWN, _ref, :process, _pid, _reason}, %{pdl: pdl} = state) do
     # The loader process died, so reset the status of any keys that were in the :loading
     # or :request_loading states to unloaded.
-    LoadState.unload(
-      pdl.load_state_manager,
-      LoadState.loading_keys(pdl.load_state_manager)
-    )
+    pending_keys =
+      LoadState.loading_keys(pdl.load_state_manager) ++
+        LoadState.reload_loading_keys(pdl.load_state_manager)
 
-    LoadState.unload(
-      pdl.load_state_manager,
-      LoadState.reload_loading_keys(pdl.load_state_manager)
-    )
+    LoadState.unload(pdl.load_state_manager, pending_keys)
 
     {:noreply, %{state | load_task_ref: nil}}
   end

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -70,9 +70,12 @@ defmodule PayDayLoan.LoadWorker do
   def handle_info({:DOWN, _ref, :process, _pid, _reason}, %{pdl: pdl} = state) do
     # The loader process died, so reset the status of any keys that were in the :loading
     # or :request_loading states to unloaded.
+
     pending_keys =
       LoadState.loading_keys(pdl.load_state_manager) ++
         LoadState.reload_loading_keys(pdl.load_state_manager)
+
+    IO.puts("Pending keyes: #{pending_keys}")
 
     LoadState.unload(pdl.load_state_manager, pending_keys)
 

--- a/lib/pay_day_loan/load_worker.ex
+++ b/lib/pay_day_loan/load_worker.ex
@@ -75,8 +75,6 @@ defmodule PayDayLoan.LoadWorker do
       LoadState.loading_keys(pdl.load_state_manager) ++
         LoadState.reload_loading_keys(pdl.load_state_manager)
 
-    IO.puts("Pending keyes: #{pending_keys}")
-
     LoadState.unload(pdl.load_state_manager, pending_keys)
 
     {:noreply, %{state | load_task_ref: nil}}

--- a/test/pay_day_loan/backends/generic_test.exs
+++ b/test/pay_day_loan/backends/generic_test.exs
@@ -427,4 +427,14 @@ defmodule PayDayLoan.Backends.GenericTest do
              "Function #{inspect(f)} not exported"
     end
   end
+
+  test "requesting a key that causes a timeout crash in the load process" do
+    key = Implementation.key_that_times_out_during_bulk_load()
+
+    assert {:error, :timed_out} == Cache.get(key)
+
+    # The final check is that even after a previous failure, the keys are marked requested
+    # when we try to get them:
+    assert :requested == PDL.query_load_state(Cache.pdl(), key)
+  end
 end

--- a/test/pay_day_loan/backends/generic_test.exs
+++ b/test/pay_day_loan/backends/generic_test.exs
@@ -427,14 +427,4 @@ defmodule PayDayLoan.Backends.GenericTest do
              "Function #{inspect(f)} not exported"
     end
   end
-
-  test "requesting a key that causes a timeout crash in the load process" do
-    key = Implementation.key_that_times_out_during_bulk_load()
-
-    assert {:error, :timed_out} == Cache.get(key)
-
-    # The final check is that even after a previous failure, the keys are marked requested
-    # when we try to get them:
-    assert :requested == PDL.query_load_state(Cache.pdl(), key)
-  end
 end

--- a/test/pay_day_loan/backends/no_retry_test.exs
+++ b/test/pay_day_loan/backends/no_retry_test.exs
@@ -21,7 +21,7 @@ defmodule PayDayLoan.Backends.NoRetryTest do
     )
   end
 
-  # loader behaviour implementation
+  # Dummy loader behaviour implementation
   defmodule Implementation do
     use PayDayLoan.Support.TestImplementation
 
@@ -29,7 +29,7 @@ defmodule PayDayLoan.Backends.NoRetryTest do
       {:ok, value}
     end
 
-    def on_remove(key, _value) do
+    def on_remove(_key, _value) do
     end
 
     def on_replace(_old_value, _key, _value) do

--- a/test/pay_day_loan/backends/no_retry_test.exs
+++ b/test/pay_day_loan/backends/no_retry_test.exs
@@ -1,0 +1,68 @@
+defmodule PayDayLoan.Backends.NoRetryTest do
+  use ExUnit.Case
+
+  alias PayDayLoan, as: PDL
+
+  import PayDayLoanTest.Support, only: [wait_for: 1]
+
+  alias PayDayLoanTest.Support.LoadHistory
+  alias PayDayLoan.LoadState
+
+  # our cache for testing
+  defmodule Cache do
+    # we override batch_size here so we can test overrides -
+    #   this is not necessary in general use
+    use(
+      PayDayLoan,
+      batch_size: 10,
+      load_num_tries: 1,
+      load_wait_msec: 50,
+      callback_module: PayDayLoan.Backends.NoRetryTest.Implementation
+    )
+  end
+
+  # loader behaviour implementation
+  defmodule Implementation do
+    use PayDayLoan.Support.TestImplementation
+
+    def on_new(_key, value) do
+      {:ok, value}
+    end
+
+    def on_remove(key, _value) do
+    end
+
+    def on_replace(_old_value, _key, _value) do
+      {:ok, "replaced"}
+    end
+
+    def on_update(_old_value, _key, value) do
+      {:ok, value}
+    end
+  end
+
+  use PayDayLoan.Support.CommonTests, cache: Cache
+
+  test "requesting a key that causes a timeout crash in the load process" do
+    reloading_key = Implementation.key_that_reloads_slowly()
+
+    Patiently.wait_for!(fn ->
+      {result, _} = Cache.get(reloading_key)
+      result == :ok
+    end)
+
+    LoadState.reload_loading(Cache.pdl().load_state_manager, reloading_key)
+
+    key = Implementation.key_that_times_out_during_bulk_load()
+    assert {:error, :timed_out} == Cache.get(key)
+
+    # The keys should no longer exist in the load state - unload is supposed to remove them.
+    assert nil == PDL.peek_load_state(Cache.pdl(), key)
+    assert nil == PDL.peek_load_state(Cache.pdl(), reloading_key)
+
+    # The final check is that even after a previous failure, the keys are marked requested
+    # when we try to get them:
+    assert :requested == PDL.query_load_state(Cache.pdl(), key)
+    assert :requested == PDL.query_load_state(Cache.pdl(), reloading_key)
+  end
+end

--- a/test/support/test_implementation.ex
+++ b/test/support/test_implementation.ex
@@ -15,6 +15,7 @@ defmodule PayDayLoan.Support.TestImplementation do
       @key_that_returns_ignore_on_new "key that returns ignore on new"
       @key_that_returns_ignore_on_refresh "key that returns ignore on refresh"
       @key_that_is_removed_from_backend "key that is removed from backend"
+      @key_that_times_out_during_bulk_load "key that times out during bulk load"
 
       # we'll refuse to load this key
       def key_that_shall_not_be_loaded do
@@ -67,8 +68,19 @@ defmodule PayDayLoan.Support.TestImplementation do
         @key_that_is_removed_from_backend
       end
 
+      # this key causes a timeout crash in the loader itself
+      def key_that_times_out_during_bulk_load do
+        @key_that_times_out_during_bulk_load
+      end
+
       def bulk_load(keys) do
         LoadHistory.loaded(keys)
+
+        if Enum.any?(keys, fn k -> k == key_that_times_out_during_bulk_load() end) do
+          # simulate a typical pattern match error that happens when we get a timeout
+          # during bulk load and don't recover gracefully
+          :ok = :timed_out
+        end
 
         keys =
           keys

--- a/test/support/test_implementation.ex
+++ b/test/support/test_implementation.ex
@@ -79,7 +79,7 @@ defmodule PayDayLoan.Support.TestImplementation do
         if Enum.any?(keys, fn k -> k == key_that_times_out_during_bulk_load() end) do
           # simulate a typical pattern match error that happens when we get a timeout
           # during bulk load and don't recover gracefully
-          :ok = :timed_out
+          exit(:timed_out)
         end
 
         keys =


### PR DESCRIPTION
[INT-5084](https://simplifi.atlassian.net/browse/INT-5084)

On the most recent budgetron deploy we noticed that some campaigns would get stuck in the :loading state if their query timed out.  Josh tracked this down to being a problem in PayDayLoan.

This change adds some logic to our :DOWN handler for the loader process, that will rest any pending keys (:loading or :reload_loading) back to :unloaded, so that they will try again.

One _potential_ issue this could introduce: the current behavior had a sort of silver lining, in that if a campaign really was completely crashing on load, it would effectively get taken out of the queue permanently (along with whatever unfortunate campaigns were in its batch).  I don't really think that's something we should concern ourselves with at the moment, but please let me know if you think otherwise...